### PR TITLE
Model / Schema basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,200 @@ In addition to `State`:
 
 [redux]: http://redux.js.org/
 [immutablejs]: https://facebook.github.io/immutable-js/
+
+# API
+
+## State
+
+State is the most basic type in Vry. It allows you to create instances of a type with defaults in place, identify instances, merge them, serialize them back to plain javascript objects as well as spec.
+
+
+### var type = State.create(name, defaults)
+
+Create a new type of State. Returns an object with methods to work with the created state type. 
+
+- `name` - (required) name of the state type
+- `defaults` - plain object or `Immutable.Iterable` of default key-value pairs that are used as the base of every instance
+
+```
+const Vry = require('vry')
+
+const User = Vry.State.create('user', {
+  name: 'New user',
+  email: null,
+  activated: false
+})
+```
+
+Note: All methods are bound to the state itself, so you can call them without binding them manually. For the unbound versions, see the prototype of the created type (`state.prototype`). Methods added after creation are not bound automatically.
+
+### var isStateInstance = State.isState(maybeState)
+
+Returns a boolean indicating whether the passed value is an instance of **any** state type. It's useful where `Immutable.Map.isMap` is not sufficient for your logic, for example when you need to know the meta attributes are present.
+
+- `maybeState` - any value
+
+```
+const notStateUser = Immutable.Map({ name: 'Homer '})
+const user = User.factory(notStateUser)
+
+console.log(State.isState(notStateUser)) // false
+console.log(State.isState(user)) // true
+```
+
+### var defaults = type.defaults()
+
+Returns the defaults as defined with `State.create`, represented as an `Immutable.Map`.
+
+```
+const User = Vry.State.create('user', {
+  name: 'New user',
+  email: null,
+  activated: false
+})
+
+const defaults = User.defaults()
+
+console.log(defaults)
+//  Immutable.Map {
+//    name: 'New user',
+//    email: null,
+//    activated: false
+//  }
+```
+
+### var name = type.typeName()
+
+Returns the name (string) as defined with `State.create`.
+
+```
+const User = Vry.State.create('user', {
+  name: 'New user',
+  email: null,
+  activated: false
+})
+
+const name = User.typeName()
+
+console.log(name) // 'user'
+```
+
+### var instance = type.factory(attributes, options)
+
+Returns a new instance (`Immutable.Map`) of the state type using the type's defaults as a base and populated with the passed attributes. It also adds some meta data to keep track of the instance identity.
+
+- `attributes` - `object` or any `Immutable.Iterable` of key-value pairs with which the type defaults will be overridden and amended. Nested `object`s and `array`s are converted to `Immutable.Map`and `Immutable.List` respectively, while any `Immutable.Iterable`s will be left untouched. 
+- `options` - `object` with the following keys
+  - `parse` - `function` as described by `type.parse` that is to be used instead of `type.parse` to transform the passed in `attributes`.
+
+```
+const User = Vry.State.create('user', {
+  name: 'New user',
+  email: null,
+  activated: false
+})
+
+const user = User.factory({
+  name: 'Homer'
+})
+
+console.log(user)
+//  Immutable.Map {
+//    name: 'Homer',
+//    email: null,
+//    activated: false
+//  }
+```
+
+### var isTypeInstance = type.instanceOf(maybeInstance)
+
+Returns a boolean indicating whether the passed value is an "instance" of this type. 
+
+- `maybeInstance` - any value
+
+```
+const user = User.factory()
+const post = Post.factory()
+
+console.log(User.instanceOf(user)) // true
+console.log(User.instanceOf(post)) // false
+```
+
+### var isCollectionOfType = type.collectionOf(maybeCollection)
+
+Returns a boolean indicating whether the passed value is an `Immutable.Collection` (and so by extension things like `Immutable.List`, `Immutable.Set`, etc) of which all values are an instance of that type. Basically `collection.every(type.instanceOf)`.
+
+- `maybeCollection` - any value
+
+```
+const users = Immutable.List([
+  User.factory(),
+  User.factory()
+])
+
+const posts = Immutable.List([
+  Post.factory(),
+  Post.factory()
+])
+
+const mixed = Immutable.List([
+  User.factory(),
+  Post.factory()
+])
+
+console.log(User.collectionOf(users)) // true
+console.log(User.collectionOf(posts)) // false
+console.log(User.collectionOf(mixed)) // false
+```
+
+### var transformedMap = type.parse(attributes)
+
+A place to implement custom parsing behaviour. This method gets called by `type.factory` unless it got called with a `parse` option, in which case `type.parse` will be ignored. 
+
+Must return a `Immutable.Iterable`. Any `Immutable.Seq`s returned are converted into `Immutable.Map` and `Immutable.List`. By default this method is a no-op, simply returning the attributes passed in.
+
+- `attributes` - (required) `Immutable.Map` of attributes. Any plain `object`s or `array`s are represented as `Immutable.Seq`s (`Keyed` and `Indexed` respectively), making it easy to deal with nested collections with a uniform API and giving you the opportunity to convert them to something else like a `Set`.
+
+```
+const User = Vry.State.create('user', {
+  name: 'New user',
+  email: null,
+  activated: false
+})
+
+User.parse = (attributes) => {
+  // Make sure names start with a capital
+  const name = attributes.get('name')
+
+  return attributes.set('name', name.charAt(0).toUpperCase() + name.slice(1))
+}
+
+const user = User.factory({
+  name: 'homer'
+})
+
+console.log(user.get('name')) // "Homer"
+```
+
+### var serialized = type.serialize(instance, options)
+
+Returns the passed instance as a plain object. 
+
+- `instance` - (required) `Immutable.Iterable` that represents an instance created with `type.factory`
+- `options` - `object` with the following keys
+  - `omitMeta` - when falsey the identity meta data will be included in the result. Defaults to `true`
+
+```
+const user = User.factory({
+  name: 'Homer'
+})
+
+const plainUser = User.serialize(user)
+
+console.log(plainUser)
+// {
+//  name: 'Homer',
+//  email: null,
+//  activated: false
+// }
+```

--- a/README.md
+++ b/README.md
@@ -282,3 +282,27 @@ console.log(plainUser)
 //  activated: false
 // }
 ```
+
+### var mergedInstance = type.merge(target, source)
+
+Merges anything from plain attributes to other instances (of the same type) with an existing instance. Any attributes present in the `source` will override the ones in `target`, except for the meta data of `target`.
+
+- `target` - (required) `Immutable.Iterable` that represents an instance created with `type.factory` which will be the target of this merge
+- `source` - (required) `object` or `Immutable.Iterable` of attributes to be merged with the target
+
+```js
+const homer = User.factory({
+  name: 'Homer'
+})
+
+const activatedHomer = User.merge(homer, {
+  activated: true
+})
+
+console.log(activatedHomer)
+//  Immutable.Map {
+//    name: 'Homer',
+//    email: null,
+//    activated: true
+//  }
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Vry
 
-### Warning! Experimental: cool, but in progress of being built and figured out
+Define `Model` and `Collection` like types to manage your `Immutable` data structures in a functional way
 
-Defining models using [Immutable.js][immutablejs], making it easier to define defaults, parsing, serialisation, merging, identifiying entities, etc. Models are stateless (anaemic), meaning the instances ([Immutable.Map](https://facebook.github.io/immutable-js/docs/#/Map)s) are passed to the Model's methods as the first argument and a new / updated version is returned. This makes them a great fit to implement [Redux reducers][redux].
+## Overview
 
-This documentation is still incredibly sparse, but I'm tired of copying / pasting this between projects. Having a look at or running the tests is probably your best bet to get an idea of how it's supposed to work. While experimental the basic behaviours have been developed throughout a sequence of various projects, so **semver will be respected**.
+[Immutable.js](https://facebook.github.io/immutable-js/) gives us great basic data constructs like `Map`, `List` and `Set`. Vry makes it straightforward to define types that house common logic for managing your immutable data. Types, generated of templates like `Model`, `Collection` and `Ref` are objects of stateless functions. This means that the instances ([Immutable.Map](https://facebook.github.io/immutable-js/docs/#/Map)s) are passed to the Type's methods as the first argument and a new / updated version is returned. This makes them a great fit to implement [Redux reducers][redux].
+
+The project is not yet complete, with constructs being added as I find a good way to express and abstract them. While still somewhat **experimental** the basic behaviours have been developed throughout a sequence of various projects, so **semver will be respected**.
+
+Documentation so far is limited to an [API reference](#api), which should be enough to get started, but I'd be happy to add guides.
+
+## Usage
 
 Use in your project:
 
@@ -12,7 +18,7 @@ Use in your project:
 npm install --save vry
 ```
 
-To run tests in vry root:
+To run tests, in vry root run:
 
 ```
 npm install --dev
@@ -71,7 +77,7 @@ const users = Immutable.List([homer]);
 const usersWithEmails = users.filter(User.hasEmail);
 ```
 
-### Motivation
+## Motivation
 
 Working with a single state tree for your application state (like [Redux][redux]) is great, but requires changes to be immutable. Using [Immutable.js][immutablejs] makes for a great fit, however, all you get are basic constructs like `Map`, `List`, `Set`. And while there is a `Record` construct, it still means that a lot of generic behaviour for entities has to be written by hand. Through a sequence of projects this represents the basics that keep coming back.
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ In addition to `State`:
 
 # API
 
-- [`State`](#state)
-- [`Model`](#model)
-- [`Ref`](#ref)
-- [`Schema`](#schema)
+- [`State`](#state) - the most basic type generator in Vry
+- [`Model`](#model) - like `State` but with better support for nesting using a `Schema`
+- [`Schema`](#schema) - to specify how various types compose together
+- [`Ref`](#ref) - a `State` type to make refering to other state easier
 
 ## State
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In addition to `State`:
 
 State is the most basic type in Vry. It allows you to create instances of a type with defaults in place, identify instances, merge them and serialize them back to plain javascript objects.
 
-### var type = State.create(name, defaults)
+### var state = State.create(name, defaults)
 
 Create a new type of State. Returns an object with methods to work with the created state type. 
 
@@ -127,7 +127,7 @@ console.log(State.isState(notStateUser)) // false
 console.log(State.isState(user)) // true
 ```
 
-### var defaults = type.defaults()
+### var defaults = state.defaults()
 
 Returns the defaults as defined with `State.create`, represented as an `Immutable.Map`.
 
@@ -148,7 +148,7 @@ console.log(defaults)
 //  }
 ```
 
-### var name = type.typeName()
+### var name = state.typeName()
 
 Returns the name (string) as defined with `State.create`.
 
@@ -164,13 +164,13 @@ const name = User.typeName()
 console.log(name) // 'user'
 ```
 
-### var instance = type.factory(attributes, options)
+### var instance = state.factory(attributes, options)
 
 Returns a new instance (`Immutable.Map`) of the state type using the type's defaults as a base and populated with the passed attributes. It also adds some meta data to keep track of the instance identity.
 
 - `attributes` - `object` or any `Immutable.Iterable` of key-value pairs with which the type defaults will be overridden and amended. Nested `object`s and `array`s are converted to `Immutable.Map`and `Immutable.List` respectively, while any `Immutable.Iterable`s will be left untouched. 
 - `options` - `object` with the following keys
-  - `parse` - `function` as described by `type.parse` that is to be used instead of `type.parse` to transform the passed in `attributes`.
+  - `parse` - `function` as described by `state.parse` that is to be used instead of `state.parse` to transform the passed in `attributes`.
 
 ```js
 const User = Vry.State.create('user', {
@@ -191,9 +191,9 @@ console.log(user)
 //  }
 ```
 
-### var isTypeInstance = type.instanceOf(maybeInstance)
+### var isTypeInstance = state.instanceOf(maybeInstance)
 
-Returns a boolean indicating whether the passed value is an "instance" of this type. 
+Returns a boolean indicating whether the passed value is an "instance" of this state. 
 
 - `maybeInstance` - any value
 
@@ -205,9 +205,9 @@ console.log(User.instanceOf(user)) // true
 console.log(User.instanceOf(post)) // false
 ```
 
-### var isCollectionOfType = type.collectionOf(maybeCollection)
+### var isCollectionOfType = state.collectionOf(maybeCollection)
 
-Returns a boolean indicating whether the passed value is an `Immutable.Collection` (and so by extension things like `Immutable.List`, `Immutable.Set`, etc) of which all values are an instance of that type. Basically `collection.every(type.instanceOf)`.
+Returns a boolean indicating whether the passed value is an `Immutable.Collection` (and so by extension things like `Immutable.List`, `Immutable.Set`, etc) of which all values are an instance of that state. Basically `collection.every(state.instanceOf)`.
 
 - `maybeCollection` - any value
 
@@ -232,9 +232,9 @@ console.log(User.collectionOf(posts)) // false
 console.log(User.collectionOf(mixed)) // false
 ```
 
-### var transformedMap = type.parse(attributes)
+### var transformedMap = state.parse(attributes)
 
-A place to implement custom parsing behaviour. This method gets called by `type.factory` unless it got called with a `parse` option, in which case `type.parse` will be ignored. 
+A place to implement custom parsing behaviour. This method gets called by `state.factory` unless it got called with a `parse` option, in which case `state.parse` will be ignored. 
 
 Must return a `Immutable.Iterable`. Any `Immutable.Seq`s returned are converted into `Immutable.Map` and `Immutable.List`. By default this method is a no-op, simply returning the attributes passed in.
 
@@ -261,11 +261,11 @@ const user = User.factory({
 console.log(user.get('name')) // "Homer"
 ```
 
-### var serialized = type.serialize(instance, options)
+### var serialized = state.serialize(instance, options)
 
 Returns the passed instance as a plain object. 
 
-- `instance` - (required) `Immutable.Iterable` that represents an instance created with `type.factory`
+- `instance` - (required) `Immutable.Iterable` that represents an instance created with `state.factory`
 - `options` - `object` with the following keys
   - `omitMeta` - when falsey the identity meta data will be included in the result. Defaults to `true`
 
@@ -284,11 +284,11 @@ console.log(plainUser)
 // }
 ```
 
-### var mergedInstance = type.merge(target, source)
+### var mergedInstance = state.merge(target, source)
 
 Merges anything from plain attributes to other instances (even of a different type) with an existing instance. Any attributes present in the `source` will override the ones in `target`, except for the meta data of `target`.
 
-- `target` - (required) `Immutable.Iterable` that represents an instance created with `type.factory` which will be the target of this merge
+- `target` - (required) `Immutable.Iterable` that represents an instance created with `state.factory` which will be the target of this merge
 - `source` - (required) `object` or `Immutable.Iterable` of attributes to be merged with the target
 
 ```js
@@ -312,14 +312,14 @@ console.log(activatedHomer)
 
 The `Model` is a lot like `State`, but goes beyond the basics of just maintaining an entity's identity and defaults. So far that means enhanced parsing and serialising of nested models within other models by use of a `Schema`. Soon merging will join that club too, as well the concept of comparing instances by id attributes. Any other enhancements to working with entities that go beyond the logic of a single depth entity (`State`) that we'll make in the future will probably end up on `Model` too. 
 
-### var type = Model.create(spec)
+### var model = Model.create(spec)
 
 Create a new type of Model. Returns an object with methods to work with the created model type.
 
 - `spec` - (required) string or object - either a string with the name of the model type or an object with values for the following properties:
   - `typeName` - (required) name of the model type
   - `defaults` - plain object or `Immutable.Iterable` of default key-value pairs that are used as the base of every instance. Same as `defaults` argument for `State.create(name, defaults)`
-  - `schema` - schema definition that describes any nested models. See the documentation for `Schema` 
+  - `schema` - schema definition that describes any nested models. See the documentation for [`Schema`](#schema).
 
 ```js
 const Vry = require('vry')
@@ -367,7 +367,7 @@ console.log(Model.isModel(notStateUser)) // false
 console.log(Model.isModel(user)) // true
 ```
 
-### var defaults = type.defaults()
+### var defaults = model.defaults()
 
 Returns the defaults as defined with `Model.create`, represented as an `Immutable.Map`.
 
@@ -392,7 +392,7 @@ console.log(defaults)
 //  }
 ```
 
-### var typeName = type.typeName()
+### var typeName = model.typeName()
 
 Returns the name (string) as defined with `Model.create`.
 
@@ -410,6 +410,202 @@ const User = Vry.Model.create({
 const typeName = User.typeName()
 
 console.log(typeName) // 'user'
+```
+
+### var instance = model.factory(attributes, options)
+
+Returns a new instance (`Immutable.Map`) of the model using the model's defaults as a base and populated with the passed attributes. It also adds some meta data to keep track of the instance identity and uses the defined schema to defer creating nested models with their own `factory` methods.
+
+- `attributes` - `object` or any `Immutable.Iterable` of key-value pairs with which the type defaults will be overridden and amended. The model's schema is used to handle the creation of nested instances. Nested `object`s and `array`s are converted to `Immutable.Map`and `Immutable.List` respectively, while any `Immutable.Iterable`s will be left untouched. 
+- `options` - `object` with the following keys
+  - `parse` - `function` as described by `state.parse` that is to be used instead of `state.parse` to transform the passed in `attributes`.
+
+```js
+
+const User = Vry.Model.create({
+  typeName: 'user',
+
+  defaults: {
+    name: 'New user',
+    email: null,
+    activated: false
+  }
+})
+
+const Post = Vry.Model.create({
+  typeName: 'post',
+
+  defaults: {
+    title: 'Untitled post',
+    body: '',
+    author: null
+  },
+
+  schema: {
+    author: User
+  }
+})
+
+const post = Post.factory({
+  title: 'A Totally Great Post',
+  author: {
+    name: 'Homer'
+  }
+})
+
+console.log(post)
+//  Immutable.Map {
+//    title: 'A Totally Great Post',
+//    body: '',
+//    author: Immutable.Map {
+//      name: 'Homer',
+//      email: null,
+//      activated: false
+//    }
+//  }
+```
+
+### var isTypeInstance = model.instanceOf(maybeInstance)
+
+Returns a boolean indicating whether the passed value is an "instance" of this type. 
+
+- `maybeInstance` - any value
+
+```js
+const user = User.factory()
+const post = Post.factory()
+
+console.log(User.instanceOf(user)) // true
+console.log(User.instanceOf(post)) // false
+```
+
+### var isCollectionOfType = model.collectionOf(maybeCollection)
+
+Returns a boolean indicating whether the passed value is an `Immutable.Collection` (and so by extension things like `Immutable.List`, `Immutable.Set`, etc) of which all values are an instance of that type. Basically `collection.every(model.instanceOf)`.
+
+- `maybeCollection` - any value
+
+```js
+const users = Immutable.List([
+  User.factory(),
+  User.factory()
+])
+
+const posts = Immutable.List([
+  Post.factory(),
+  Post.factory()
+])
+
+const mixed = Immutable.List([
+  User.factory(),
+  Post.factory()
+])
+
+console.log(User.collectionOf(users)) // true
+console.log(User.collectionOf(posts)) // false
+console.log(User.collectionOf(mixed)) // false
+```
+
+### var transformedMap = model.parse(attributes)
+
+A place to implement custom parsing behaviour. This method gets called by `type.factory` unless it got called with a `parse` option, in which case `type.parse` will be ignored. 
+
+Must return a `Immutable.Iterable`. Any `Immutable.Seq`s returned are converted into `Immutable.Map` and `Immutable.List`.
+
+By default it uses the `Schema` of the model to defer the parsing of other nested models to their own methods. 
+
+- `attributes` - (required) `Immutable.Map` of attributes. Any plain `object`s or `array`s are represented as `Immutable.Seq`s (`Keyed` and `Indexed` respectively), making it easy to deal with nested collections with a uniform API and giving you the opportunity to convert them to something else like a `Set`.
+- `options` - `object` with values for the following keys
+  - `schema` - schema definition that describes any nested models, to be used instead of the schema defined for the model. See the documentation for [`Schema`](#schema).
+
+```js
+const User = Vry.Model.create({
+  typeName: 'user',
+
+  defaults: {
+    name: 'New user',
+    email: null,
+    activated: false
+  }
+})
+
+User.parse = (attributes) => {
+  // Make sure names start with a capital
+  const name = attributes.get('name')
+
+  return attributes.set('name', name.charAt(0).toUpperCase() + name.slice(1))
+}
+
+const Post = Vry.Model.create({
+  typeName: 'post',
+
+  defaults: {
+    title: 'Untitled post',
+    body: '',
+    author: null
+  },
+
+  schema: {
+    author: User
+  }
+})
+
+const post = Post.factory({
+  title: 'Nice post',
+  author: {
+    name: 'homer'
+  }
+})
+
+console.log(post.get('user').get('name')) // "Homer"
+```
+
+### var serialized = model.serialize(instance, options)
+
+Returns the passed instance as a plain object. Defers the serialising of nested types to their `serialize` methods when defined (see [`Schema`](#schema)).
+
+- `instance` - (required) `Immutable.Iterable` that represents an instance created with `state.factory`
+- `options` - `object` with the following keys
+  - `omitMeta` - when falsey the identity meta data will be included in the result. Defaults to `true`
+  - `schema` - schema definition that describes any nested models, to be used instead of the schema defined for the model. See the documentation for [`Schema`](#schema).
+
+```js
+const user = User.factory({
+  name: 'Homer'
+})
+
+const plainUser = User.serialize(user)
+
+console.log(plainUser)
+// {
+//  name: 'Homer',
+//  email: null,
+//  activated: false
+// }
+```
+
+### var mergedInstance = model.merge(target, source)
+
+Merges anything from plain attributes to other instances (even of a different type) with an existing instance. Any attributes present in the `source` will override the ones in `target`, except for the meta data of `target`.
+
+- `target` - (required) `Immutable.Iterable` that represents an instance created with `model.factory` which will be the target of this merge
+- `source` - (required) `object` or `Immutable.Iterable` of attributes to be merged with the target
+
+```js
+const homer = User.factory({
+  name: 'Homer'
+})
+
+const activatedHomer = User.merge(homer, {
+  activated: true
+})
+
+console.log(activatedHomer)
+//  Immutable.Map {
+//    name: 'Homer',
+//    email: null,
+//    activated: true
+//  }
 ```
 
 ## Ref

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ console.log(plainUser)
 
 ### var mergedInstance = type.merge(target, source)
 
-Merges anything from plain attributes to other instances (of the same type) with an existing instance. Any attributes present in the `source` will override the ones in `target`, except for the meta data of `target`.
+Merges anything from plain attributes to other instances (even of a different type) with an existing instance. Any attributes present in the `source` will override the ones in `target`, except for the meta data of `target`.
 
 - `target` - (required) `Immutable.Iterable` that represents an instance created with `type.factory` which will be the target of this merge
 - `source` - (required) `object` or `Immutable.Iterable` of attributes to be merged with the target

--- a/README.md
+++ b/README.md
@@ -306,3 +306,33 @@ console.log(activatedHomer)
 //    activated: true
 //  }
 ```
+## Ref
+
+### var ref = Ref.create(path)
+
+### var subject = Ref.resolve(ref, source)
+
+### var collection = Ref.resolveCollection(ref, source)
+
+### var subject = Ref.replaceIn(source, subject, ...paths)
+
+
+## Schema 
+
+A `Schema` is an object to describe the relationships between various `Model` types. Each `Model` type has one, detailing what other `Model` types are embedded within it and with what shape.
+
+### var isSchema = Schema.isSchema(maybeSchema)
+
+### var isIterableSchema = Schema.isIterableSchema(maybeSchema)
+
+### var isType = Schema.isType(maybeSchema)
+
+### var listSchema = Schema.listOf(modelType)
+
+### var setSchema =  Schema.setOf(modelType)
+
+### var orderedSetSchema = Schema.orderedSetOf(modelType)
+
+### Schema.orderedSetOf
+
+

--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ In addition to `State`:
 
 ## State
 
-State is the most basic type in Vry. It allows you to create instances of a type with defaults in place, identify instances, merge them, serialize them back to plain javascript objects as well as spec.
-
+State is the most basic type in Vry. It allows you to create instances of a type with defaults in place, identify instances, merge them and serialize them back to plain javascript objects.
 
 ### var type = State.create(name, defaults)
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ In addition to `State`:
 
 # API
 
+- [`State`](#state)
+- [`Model`](#model)
+- [`Ref`](#ref)
+- [`Schema`](#schema)
+
 ## State
 
 State is the most basic type in Vry. It allows you to create instances of a type with defaults in place, identify instances, merge them and serialize them back to plain javascript objects.

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ A place to implement custom parsing behaviour. This method gets called by `type.
 
 Must return a `Immutable.Iterable`. Any `Immutable.Seq`s returned are converted into `Immutable.Map` and `Immutable.List`.
 
-By default it uses the `Schema` of the model to defer the parsing of other nested models to their own methods. 
+By default it uses the `Schema` of the model to defer the parsing of other nested models to their own methods. If the passed value is a `Ref` instance, the `Schema`'s `factory` is ignored.
 
 - `attributes` - (required) `Immutable.Map` of attributes. Any plain `object`s or `array`s are represented as `Immutable.Seq`s (`Keyed` and `Indexed` respectively), making it easy to deal with nested collections with a uniform API and giving you the opportunity to convert them to something else like a `Set`.
 - `options` - `object` with values for the following keys

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Create a new type of State. Returns an object with methods to work with the crea
 - `name` - (required) name of the state type
 - `defaults` - plain object or `Immutable.Iterable` of default key-value pairs that are used as the base of every instance
 
-```
+```js
 const Vry = require('vry')
 
 const User = Vry.State.create('user', {
@@ -118,7 +118,7 @@ Returns a boolean indicating whether the passed value is an instance of **any** 
 
 - `maybeState` - any value
 
-```
+```js
 const notStateUser = Immutable.Map({ name: 'Homer '})
 const user = User.factory(notStateUser)
 
@@ -130,7 +130,7 @@ console.log(State.isState(user)) // true
 
 Returns the defaults as defined with `State.create`, represented as an `Immutable.Map`.
 
-```
+```js
 const User = Vry.State.create('user', {
   name: 'New user',
   email: null,
@@ -151,7 +151,7 @@ console.log(defaults)
 
 Returns the name (string) as defined with `State.create`.
 
-```
+```js
 const User = Vry.State.create('user', {
   name: 'New user',
   email: null,
@@ -171,7 +171,7 @@ Returns a new instance (`Immutable.Map`) of the state type using the type's defa
 - `options` - `object` with the following keys
   - `parse` - `function` as described by `type.parse` that is to be used instead of `type.parse` to transform the passed in `attributes`.
 
-```
+```js
 const User = Vry.State.create('user', {
   name: 'New user',
   email: null,
@@ -196,7 +196,7 @@ Returns a boolean indicating whether the passed value is an "instance" of this t
 
 - `maybeInstance` - any value
 
-```
+```js
 const user = User.factory()
 const post = Post.factory()
 
@@ -210,7 +210,7 @@ Returns a boolean indicating whether the passed value is an `Immutable.Collectio
 
 - `maybeCollection` - any value
 
-```
+```js
 const users = Immutable.List([
   User.factory(),
   User.factory()
@@ -239,7 +239,7 @@ Must return a `Immutable.Iterable`. Any `Immutable.Seq`s returned are converted 
 
 - `attributes` - (required) `Immutable.Map` of attributes. Any plain `object`s or `array`s are represented as `Immutable.Seq`s (`Keyed` and `Indexed` respectively), making it easy to deal with nested collections with a uniform API and giving you the opportunity to convert them to something else like a `Set`.
 
-```
+```js
 const User = Vry.State.create('user', {
   name: 'New user',
   email: null,
@@ -268,7 +268,7 @@ Returns the passed instance as a plain object.
 - `options` - `object` with the following keys
   - `omitMeta` - when falsey the identity meta data will be included in the result. Defaults to `true`
 
-```
+```js
 const user = User.factory({
   name: 'Homer'
 })

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ As we've implemented it so far the `Ref` points to something by use of a path. W
 
 ### var ref = Ref.create(path)
 
-Returns a `Immutable.Map` that represents the `Ref` with the specified path.
+Returns a `Immutable.Map` that represents the `Ref` with the specified path and also qualifies as a `State` instance.
 
 - `path` - (required) either a string, or an array / `Immutable.List` of strings, specifying the path to target
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ const Post = Vry.Model.create({
 })
 ```
 
-Note: All methods are bound to the state itself, so you can call them without binding them manually. For the unbound versions, see the prototype of the created type (`state.prototype`). Methods added after creation are not bound automatically.
+Note: All methods are bound to the model itself, so you can call them without binding them manually. For the unbound versions, see the prototype of the created type (`model.prototype`). Methods added after creation are not bound automatically.
 
 ### var isModelInstance = Model.isModel(maybeModel)
 

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ console.log(post.get('user').get('name')) // "Homer"
 
 ### var serialized = model.serialize(instance, options)
 
-Returns the passed instance as a plain object. Defers the serialising of nested types to their `serialize` methods when defined (see [`Schema`](#schema)).
+Returns the passed instance as a plain object. Defers the serialising of nested types to their `serialize` methods when defined (see [`Schema`](#schema)). Any references (instances of `Ref`) are serialized as one.
 
 - `instance` - (required) `Immutable.Iterable` that represents an instance created with `state.factory`
 - `options` - `object` with the following keys

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Returns a boolean indicating whether the passed value is an instance of **any** 
 
 - `maybeState` - any value
 
+**Note:** with the current implementation a `Model` instance will also pass this test.
+
 ```js
 const notStateUser = Immutable.Map({ name: 'Homer '})
 const user = User.factory(notStateUser)
@@ -315,7 +317,7 @@ The `Model` is a lot like `State`, but goes beyond the basics of just maintainin
 Create a new type of Model. Returns an object with methods to work with the created model type.
 
 - `spec` - (required) string or object - either a string with the name of the model type or an object with values for the following properties:
-  - `name` - (required) name of the state type
+  - `typeName` - (required) name of the model type
   - `defaults` - plain object or `Immutable.Iterable` of default key-value pairs that are used as the base of every instance. Same as `defaults` argument for `State.create(name, defaults)`
   - `schema` - schema definition that describes any nested models. See the documentation for `Schema` 
 
@@ -323,7 +325,7 @@ Create a new type of Model. Returns an object with methods to work with the crea
 const Vry = require('vry')
 
 const User = Vry.Model.create({
-  name: 'user',
+  typeName: 'user',
 
   defaults: {
     name: 'New user',
@@ -333,7 +335,7 @@ const User = Vry.Model.create({
 })
 
 const Post = Vry.Model.create({
-  name: 'post',
+  typeName: 'post',
 
   defaults: {
     title: 'Untitled post',
@@ -348,6 +350,67 @@ const Post = Vry.Model.create({
 ```
 
 Note: All methods are bound to the state itself, so you can call them without binding them manually. For the unbound versions, see the prototype of the created type (`state.prototype`). Methods added after creation are not bound automatically.
+
+### var isModelInstance = Model.isModel(maybeModel)
+
+Returns a boolean indicating whether the passed value is an instance of **any** model type. It's useful where `Immutable.Map.isMap` is not sufficient for your logic, for example when you need to know the meta attributes are present.
+
+**Note:** with the current implementation a `State` instance will also pass this test.
+
+- `maybeModel` - any value
+
+```js
+const notStateUser = Immutable.Map({ name: 'Homer '})
+const user = User.factory(notStateUser)
+
+console.log(Model.isModel(notStateUser)) // false
+console.log(Model.isModel(user)) // true
+```
+
+### var defaults = type.defaults()
+
+Returns the defaults as defined with `Model.create`, represented as an `Immutable.Map`.
+
+```js
+const User = Vry.Model.create({
+  typeName: 'user',
+
+  defaults: {
+    name: 'New user',
+    email: null,
+    activated: false
+  }
+})
+
+const defaults = User.defaults()
+
+console.log(defaults)
+//  Immutable.Map {
+//    name: 'New user',
+//    email: null,
+//    activated: false
+//  }
+```
+
+### var typeName = type.typeName()
+
+Returns the name (string) as defined with `Model.create`.
+
+```js
+const User = Vry.Model.create({
+  typeName: 'user',
+
+  defaults: {
+    name: 'New user',
+    email: null,
+    activated: false
+  }
+})
+
+const typeName = User.typeName()
+
+console.log(typeName) // 'user'
+```
 
 ## Ref
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,50 @@ console.log(activatedHomer)
 //    activated: true
 //  }
 ```
+
+## Model
+
+The `Model` is a lot like `State`, but goes beyond the basics of just maintaining an entity's identity and defaults. So far that means enhanced parsing and serialising of nested models within other models by use of a `Schema`. Soon merging will join that club too, as well the concept of comparing instances by id attributes. Any other enhancements to working with entities that go beyond the logic of a single depth entity (`State`) that we'll make in the future will probably end up on `Model` too. 
+
+### var type = Model.create(spec)
+
+Create a new type of Model. Returns an object with methods to work with the created model type.
+
+- `spec` - (required) string or object - either a string with the name of the model type or an object with values for the following properties:
+  - `name` - (required) name of the state type
+  - `defaults` - plain object or `Immutable.Iterable` of default key-value pairs that are used as the base of every instance. Same as `defaults` argument for `State.create(name, defaults)`
+  - `schema` - schema definition that describes any nested models. See the documentation for `Schema` 
+
+```js
+const Vry = require('vry')
+
+const User = Vry.Model.create({
+  name: 'user',
+
+  defaults: {
+    name: 'New user',
+    email: null,
+    activated: false
+  }
+})
+
+const Post = Vry.Model.create({
+  name: 'post',
+
+  defaults: {
+    title: 'Untitled post',
+    body: '',
+    author: null
+  },
+
+  schema: {
+    author: User
+  }
+})
+```
+
+Note: All methods are bound to the state itself, so you can call them without binding them manually. For the unbound versions, see the prototype of the created type (`state.prototype`). Methods added after creation are not bound automatically.
+
 ## Ref
 
 ### var ref = Ref.create(path)

--- a/README.md
+++ b/README.md
@@ -613,6 +613,96 @@ console.log(activatedHomer)
 //  }
 ```
 
+
+## Schema 
+
+A `Schema` is an object to describe how other types are embedded within a given type. It specifies the shape, as well as how the embedded types should be created, identified and serialized back to plain objects and arrays. 
+
+Each `Model` type has one, detailing what other `Model` types are embedded within it.
+
+Schema's are plain javascript objects with either a type definition (see `Schema.isType`) or a nested schema specified as values. There isn't a `Schema.create` method to create schemas (yet).
+
+```js
+// user has no embedded types
+const postSchema = {
+  title: {
+    factory(value) { return value.toUpperCase() },
+    serialize(value) { return value.toLowerCase() }
+  },
+
+  author: User, // Types created with `Model.create` and `State.create` are valid type definitions!
+
+  // use `Schema.listOf` and `Schema.setOf` to convienently create types for nested 
+  comments: Schema.listOf(Comment),
+
+  metadata: { // schemas can be nested
+    tags: Schema.setOf(Tag)
+  }
+}
+```
+
+### var isSchema = Schema.isSchema(maybeSchema)
+
+Returns whether a value is a valid schema definition. A valid schema is an `object` with either a valid type definition (see `Schema.isType`) or a nested schema. 
+
+- `maybeSchema` - any value
+
+```js
+const postSchema = {
+  title: { // valid type definition
+    factory(value) { return value.toUpperCase() },
+    serialize(value) { return value.toLowerCase() }
+  }
+}
+
+const userSchema = {
+  name: "woohoo" // not a valid type definition
+}
+
+console.log(Schema.isSchema(postSchema)) // true
+console.log(Schema.isSchema(userSchema)) // false
+```
+
+### var isType = Schema.isType(maybeType)
+
+Returns whether a value is a valid type definition. 
+
+- `maybeType` - any value
+
+A valid type definition is an `object` with at least one of the following keys defined as described:
+
+- `factory` - function with the signature `var instance = function(plainValue, options)`
+- `serialize` - function with the signature `var plainValue = function(isntance, options)`
+
+The following keys can be defined as well
+
+- `instanceOf` - function with signature `var isInstance = function(maybeInstance)`
+
+### var listSchema = Schema.listOf(definition)
+
+Returns a schema definition (`IterableSchema`) describing an `Immutable.List` of a schema or type.
+
+- `definition` - either a valid schema or type definition
+
+### var setSchema =  Schema.setOf(definition)
+
+Returns a schema definition (`IterableSchema`) describing an `Immutable.Set` of a schema or type.
+
+- `definition` - either a valid schema or type definition
+
+### var orderedSetSchema = Schema.orderedSetOf(definition)
+
+Returns a schema definition (`IterableSchema`) describing an `Immutable.OrderedSet` of a schema or type.
+
+- `definition` - either a valid schema or type definition
+
+### var isIterableSchema = Schema.isIterableSchema(maybeSchema)
+
+Returns whether the value is a special `IterableSchema`, which are the special schema definitions returned by methods like `Schema.listOf`.
+
+- `maybeSchema` - any value
+
+
 ## Ref
 
 A `Ref`, short for reference, is a bit of state that points to another bit of state. In practice it's used to allow for a single instance of an entity to be stored in one place, with any other uses of it referring back to the original. It's implemented as a `State` type using `State.create`, meaning that a reference is just another `Immutable.Map` of a specific shape.
@@ -796,92 +886,3 @@ console.log(resolvedPost)
 //  }
 //  
 ```
-
-## Schema 
-
-A `Schema` is an object to describe how other types are embedded within a given type. It specifies the shape, as well as how the embedded types should be created, identified and serialized back to plain objects and arrays. 
-
-Each `Model` type has one, detailing what other `Model` types are embedded within it.
-
-Schema's are plain javascript objects with either a type definition (see `Schema.isType`) or a nested schema specified as values. There isn't a `Schema.create` method to create schemas (yet).
-
-```js
-// user has no embedded types
-const postSchema = {
-  title: {
-    factory(value) { return value.toUpperCase() },
-    serialize(value) { return value.toLowerCase() }
-  },
-
-  author: User, // Types created with `Model.create` and `State.create` are valid type definitions!
-
-  // use `Schema.listOf` and `Schema.setOf` to convienently create types for nested 
-  comments: Schema.listOf(Comment),
-
-  metadata: { // schemas can be nested
-    tags: Schema.setOf(Tag)
-  }
-}
-```
-
-### var isSchema = Schema.isSchema(maybeSchema)
-
-Returns whether a value is a valid schema definition. A valid schema is an `object` with either a valid type definition (see `Schema.isType`) or a nested schema. 
-
-- `maybeSchema` - any value
-
-```js
-const postSchema = {
-  title: { // valid type definition
-    factory(value) { return value.toUpperCase() },
-    serialize(value) { return value.toLowerCase() }
-  }
-}
-
-const userSchema = {
-  name: "woohoo" // not a valid type definition
-}
-
-console.log(Schema.isSchema(postSchema)) // true
-console.log(Schema.isSchema(userSchema)) // false
-```
-
-### var isType = Schema.isType(maybeType)
-
-Returns whether a value is a valid type definition. 
-
-- `maybeType` - any value
-
-A valid type definition is an `object` with at least one of the following keys defined as described:
-
-- `factory` - function with the signature `var instance = function(plainValue, options)`
-- `serialize` - function with the signature `var plainValue = function(isntance, options)`
-
-The following keys can be defined as well
-
-- `instanceOf` - function with signature `var isInstance = function(maybeInstance)`
-
-### var listSchema = Schema.listOf(definition)
-
-Returns a schema definition (`IterableSchema`) describing an `Immutable.List` of a schema or type.
-
-- `definition` - either a valid schema or type definition
-
-### var setSchema =  Schema.setOf(definition)
-
-Returns a schema definition (`IterableSchema`) describing an `Immutable.Set` of a schema or type.
-
-- `definition` - either a valid schema or type definition
-
-### var orderedSetSchema = Schema.orderedSetOf(definition)
-
-Returns a schema definition (`IterableSchema`) describing an `Immutable.OrderedSet` of a schema or type.
-
-- `definition` - either a valid schema or type definition
-
-### var isIterableSchema = Schema.isIterableSchema(maybeSchema)
-
-Returns whether the value is a special `IterableSchema`, which are the special schema definitions returned by methods like `Schema.listOf`.
-
-- `maybeSchema` - any value
-

--- a/README.md
+++ b/README.md
@@ -83,11 +83,10 @@ Working with a single state tree for your application state (like [Redux][redux]
 
 ### Ideas for future expansion
 
-In addition to `State`:
+Among plenty of other ideas, these are constructs I've validated the need for within my own projects:
 
-- `Model` / `Schema` allowing for things like computed properties
-- `Graph` / `Ref` making it easier to model state as graphs instead of trees
 - `Collection` abstracting basic collection behaviour like storing lists of entities under multiple indexes, merging behaviour, etc.
+- `NormalisedGraph` with a standard way of storing and referring to instances of models
 
 [redux]: http://redux.js.org/
 [immutablejs]: https://facebook.github.io/immutable-js/

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "immutable": "^3.7.6",
     "lodash.assign": "^4.0.9",
     "lodash.every": "^4.4.0",
+    "lodash.foreach": "^4.3.0",
+    "lodash.functions": "^4.1.1",
     "lodash.isarray": "^3.0.4",
     "lodash.isfunction": "^3.0.6",
     "lodash.isplainobject": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash.isplainobject": "^3.2.0",
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",
+    "lodash.keys": "^4.0.7",
     "lodash.uniqueid": "^3.0.0",
     "shortid": "^2.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "immutable": "^3.7.6",
     "lodash.assign": "^4.0.9",
+    "lodash.every": "^4.4.0",
     "lodash.isarray": "^3.0.4",
     "lodash.isfunction": "^3.0.6",
     "lodash.isplainobject": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vry",
-  "version": "1.2.0",
-  "description": "Data modeling with Immutable.js designed for use with Redux-like architectures",
+  "version": "2.0.0",
+  "description": "Define `Model` and `Collection` like types to manage your `Immutable` data structures in a functional way",
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run compile && tape -r babel-register test/index.js | tap-spec",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lodash.isundefined": "^3.0.1",
     "lodash.keys": "^4.0.7",
     "lodash.uniqueid": "^3.0.0",
-    "shortid": "^2.2.4"
+    "shortid": "^2.2.4",
+    "warning": "^3.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",

--- a/src/factory.js
+++ b/src/factory.js
@@ -22,7 +22,7 @@ exports.create = function(defaults) {
 
 	return {
 		factory: internals.factory,
-		getDefaults: () => defaults
+		defaults: () => defaults
 	}
 }
 
@@ -39,7 +39,7 @@ internals.factory = function(rawEntity={}, options={}) {
 	var parse = options.parse || this.parse || ((attrs) => attrs)
 
 	// merge with with defaults and cast any nested native selections to Seqs
-	var entity = this.getDefaults().merge(Immutable.Map(rawEntity)).map((value, key) => {
+	var entity = this.defaults().merge(Immutable.Map(rawEntity)).map((value, key) => {
 		if (Immutable.Iterable.isIterable(value)) {
 			return value
 		}

--- a/src/factory.js
+++ b/src/factory.js
@@ -55,7 +55,7 @@ internals.factory = function(rawEntity={}, options={}) {
 		return value
 	})
 
-	var parsedEntity = parse(entity)
+	var parsedEntity = parse.call(this, entity, options)
 
 	Invariant(Immutable.Iterable.isIterable(parsedEntity), 'Parse function has to return an Immutable Iterable')
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,0 +1,81 @@
+const Invariant = require('invariant')
+const Immutable = require('immutable')
+const ShortId = require('shortid')
+const _isPlainObject = require('lodash.isplainobject')
+const _isFunction = require('lodash.isfunction')
+const _isArray = require('lodash.isarray')
+var _uniqueId = require('lodash.uniqueid')
+
+const Props = require('./props')
+
+const internals = {}
+
+internals.cidPrefix = `vry-${ShortId.generate()}-`
+internals.generateCid = function() {
+	return _uniqueId(internals.cidPrefix)
+}
+
+exports.create = function(defaults) {
+	Invariant(!defaults || exports.isDefaults(defaults), 'Defaults for factory must be plain object or Immutable Iterable')
+
+	defaults = Immutable.Map(defaults || {})
+
+	return {
+		factory: internals.factory,
+		getDefaults: () => defaults
+	}
+}
+
+exports.isDefaults = (maybeDefaults) => Immutable.Iterable.isIterable(maybeDefaults) || _isPlainObject(maybeDefaults)
+
+internals.factory = function(rawEntity={}, options={}) {
+	Invariant(
+		Immutable.Iterable.isIterable(rawEntity) ||
+		_isPlainObject(rawEntity)
+	, 'Raw entity, when passed, must be a plain object or Immutable Iterable')
+	Invariant(_isPlainObject(options), 'options, when passed, must be a plain object')
+	Invariant(!options.parse || _isFunction(options.parse), 'The `parse` prop of the options, when passed, must be a function')
+
+	var parse = options.parse || this.parse || ((attrs) => attrs)
+
+	// merge with with defaults and cast any nested native selections to Seqs
+	var entity = this.getDefaults().merge(Immutable.Map(rawEntity)).map((value, key) => {
+		if (Immutable.Iterable.isIterable(value)) {
+			return value
+		}
+
+		if (_isArray(value)) {
+			return Immutable.Seq.Indexed(value)
+		}
+
+		if (_isPlainObject(value)) {
+			return Immutable.Seq.Keyed(value)
+		}
+
+		return value
+	})
+
+	var parsedEntity = parse(entity)
+
+	Invariant(Immutable.Iterable.isIterable(parsedEntity), 'Parse function has to return an Immutable Iterable')
+
+	var metaAttrs = {
+		[Props.cid]: internals.generateCid(),
+		[Props.name]: this.getName()
+	}
+
+	return parsedEntity.toKeyedSeq().map(function(value, key) {
+		if (Immutable.Seq.isSeq(value)) {
+			// cast any Seqs into either Lists or Maps
+			let isIndexed = Immutable.Iterable.isIndexed(value)
+			let collection = isIndexed ? value.toList() : value.toMap()
+
+			return collection.map(function(value) {
+				return Immutable.fromJS(value)
+			})
+		} else {
+			// cast any nested collections to immutable data
+			return Immutable.fromJS(value)
+		}
+	}).toMap().merge(metaAttrs)
+}

--- a/src/factory.js
+++ b/src/factory.js
@@ -61,7 +61,7 @@ internals.factory = function(rawEntity={}, options={}) {
 
 	var metaAttrs = {
 		[Props.cid]: internals.generateCid(),
-		[Props.name]: this.getName()
+		[Props.name]: this.typeName()
 	}
 
 	return parsedEntity.toKeyedSeq().map(function(value, key) {

--- a/src/identity.js
+++ b/src/identity.js
@@ -13,7 +13,7 @@ exports.create = function(name) {
 	Invariant(name && (typeof name === "string"), 'Name is required to create an identity');
 
 	return {
-		getName: () =>  name,
+		typeName: () =>  name,
 		
 		hasIdentity: exports.hasIdentity,
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
 exports.State = require('./state');
 exports.Ref = require('./ref');
+exports.Model = require('./model');
+exports.Schema = require('./schema');

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,0 +1,27 @@
+const Invariant = require('invariant')
+const Immutable = require('immutable')
+const _assign = require('lodash.assign')
+const _isPlainObject = require('lodash.isplainobject')
+const _keys = require('lodash.keys')
+
+const Props = require('./props')
+
+const internals = {}
+
+exports.create = function(identity, factory) {
+	return {
+		merge: internals.merge.bind(_assign({}, identity, factory))
+	}
+}
+
+internals.merge = function(state, data) {
+	Invariant(this.instanceOf(state), `Instance of ${this.typeName()} is required to merge it with new attributes`)
+	Invariant(Immutable.Iterable.isIterable(data) || _isPlainObject(data), 'Plain object or Immutable Iterable required as source to merge with the state instance')
+
+	if (!this.instanceOf(data)) {
+		let dataKeys = Immutable.Seq(Immutable.Iterable.isIterable(data) ? data.keys() : _keys(data))
+		data = this.factory(data).filter((val, key) => dataKeys.includes(key))
+	}
+
+	return state.merge(data.remove(Props.cid));
+}

--- a/src/merge.js
+++ b/src/merge.js
@@ -23,5 +23,5 @@ internals.merge = function(state, data) {
 		data = this.factory(data).filter((val, key) => dataKeys.includes(key))
 	}
 
-	return state.merge(data.remove(Props.cid));
+	return state.merge(data.remove(Props.cid).remove(Props.name));
 }

--- a/src/model.js
+++ b/src/model.js
@@ -125,17 +125,15 @@ exports.serialize = function(model, options) {
 				return modelValue
 			}
 
-			let serialized = type.serialize(modelValue, options)
-
-			if (_isFunction(serialized)) {
-				serialized = serialized(this)
-			}
-
-			return serialized
+			return type.serialize(modelValue, options)
 		} else if (Schema.isSchema(definition)) {
 			let nestedSchema = definition
 
-			if (
+			if (nestedSchema.getItemSchema) { // could be an Iterable schema
+				let itemSchema = nestedSchema.getItemSchema()
+
+				return nestedSchema.factory(this.serialize(modelValue, { schema: itemSchema }))
+			} else if (
 				Immutable.Iterable.isIndexed(modelValue) && _isArray(nestedSchema) ||
 				Immutable.Iterable.isKeyed(modelValue) && _isPlainObject(nestedSchema)
 			) {

--- a/src/model.js
+++ b/src/model.js
@@ -2,6 +2,8 @@ const Immutable = require('immutable')
 const Invariant = require('invariant')
 const _assign = require('lodash.assign')
 const _every = require('lodash.every')
+const _forEach = require('lodash.foreach')
+const _functions = require('lodash.functions')
 const _isArray = require('lodash.isarray')
 const _isPlainObject = require('lodash.isplainobject')
 const _isString = require('lodash.isstring')
@@ -61,7 +63,13 @@ exports.create = (spec) => {
 		}
 	)
 
-	let model = Object.create(modelPrototype)
+	var model = Object.create(modelPrototype)
+
+	// Binding each prototype method to the state itself. Unbound versions can still
+	// be used by accessing the prototype
+	_forEach(_functions(modelPrototype), (methodName) => {
+		model[methodName] = modelPrototype[methodName].bind(model)
+	})
 	
 	return model
 }

--- a/src/model.js
+++ b/src/model.js
@@ -77,25 +77,23 @@ exports.parse = function(attrs, options={}) {
 				// if the value is already and instance of what we're trying to make it
 				// there is nothing for us to do
 				return modelValue
-			} else {
-				let instance = type.factory(modelValue)
+			} 
+			
+			return type.factory(modelValue)
 
-				// factory can be a thunk
-				if (_isFunction(instance)) {
-					instance = instance(this.parse.bind(this))
-				}
-
-				return instance
-			}
 		} else if (Schema.isSchema(definition)) {
 			let nestedSchema = definition
 
-			if (
+			if (nestedSchema.getItemSchema) { // could be an Iterable schema
+				let itemSchema = nestedSchema.getItemSchema()
+
+				return nestedSchema.factory(this.parse(modelValue, { schema: itemSchema }))
+			} else if ( // support plain objects and arrays as they'll automatically get cast properly
 				Immutable.Iterable.isIndexed(modelValue) && _isArray(nestedSchema) ||
 				Immutable.Iterable.isKeyed(modelValue) && _isPlainObject(nestedSchema)
 			) {
 				return this.parse(modelValue, { schema: nestedSchema })
-			}
+			} 
 		}
 
 		return modelValue

--- a/src/model.js
+++ b/src/model.js
@@ -139,7 +139,10 @@ internals.serialize = function(model, options) {
 		if (Schema.isType(definition)) {
 			let type = definition
 
-			if (
+
+			if (Ref.instanceOf(modelValue)) {
+				return Ref.serialize(modelValue)
+			} else if (
 				// no serializer or the value is not an instance of the type
 				!_isFunction(type.serialize) || 
 				(_isFunction(type.instanceOf) && !Schema.instanceOfType(type, modelValue))

--- a/src/model.js
+++ b/src/model.js
@@ -48,8 +48,8 @@ exports.create = (spec) => {
 		},
 		{
 			parse: exports.parse,
-			merge: exports.merge,
-			serialize: exports.serialize
+			serialize: exports.serialize,
+			merge: State.merge
 		}
 	)
 
@@ -147,5 +147,3 @@ exports.serialize = function(model, options) {
 
 	return State.serialize(partial, options)
 }
-
-exports.merge = () => {}

--- a/src/model.js
+++ b/src/model.js
@@ -15,6 +15,13 @@ const Schema = require('./schema')
 
 const internals = {}
 
+internals.Model = function(...args) {
+	Invariant(!(this instanceof internals.Model), 'Model should not be called with `new`')
+
+	return exports.create(...args)
+}
+
+
 exports.isModel = (maybeModel) => Identity.hasIdentity(maybeModel)
 
 exports.create = (spec) => {
@@ -41,6 +48,7 @@ exports.create = (spec) => {
 	if (!schema) schema = {}
 
 	const modelPrototype = _assign(
+		Object.create(internals.Model.prototype), // makes `x instanceof Model` work
 		Identity.create(name),
 		Factory.create(defaults),
 		{
@@ -147,3 +155,5 @@ exports.serialize = function(model, options) {
 
 	return State.serialize(partial, options)
 }
+
+module.exports = _assign(internals.Model, exports) 

--- a/src/model.js
+++ b/src/model.js
@@ -4,6 +4,7 @@ const _assign = require('lodash.assign')
 const _every = require('lodash.every')
 const _isArray = require('lodash.isarray')
 const _isPlainObject = require('lodash.isplainobject')
+const _isString = require('lodash.isstring')
 const _isFunction = require('lodash.isfunction')
 
 const Identity = require('./identity')
@@ -15,9 +16,14 @@ exports.isModel = (maybeModel) => {}
 
 exports.create = (spec) => {
 	Invariant(
+		_isString(spec) ||
 		_isPlainObject(spec) &&
-		spec.name && (typeof spec.name === "string")
-	, 'A plain object (spec) with a name is required to create a model')
+		spec.name && _isString(spec.name)
+	, 'A name or a plain object (spec) with a name is required to create a model')
+
+	if (_isString(spec)) {
+		spec = { name: spec }
+	}
 
 	const {
 		name,

--- a/src/model.js
+++ b/src/model.js
@@ -138,45 +138,4 @@ exports.serialize = function(model, options) {
 	return State.serialize(partial, options)
 }
 
-
-const Schema = {
-	getDefinition(schema, prop) {
-		return _isArray(schema) ? schema[0] : 
-				schema ? schema[prop] :
-				null
-	},
-
-	isSchema(maybeSchema) {
-		return !!(
-			// objects go
-			_isPlainObject(maybeSchema) || 
-			// array with one value go
-			_isArray(maybeSchema) && maybeSchema.length === 1
-		) && _every(maybeSchema, (value, key) => {
-			return Schema.isType(value) || Schema.isSchema(value)
-		})
-	},
-
-	isType(maybeType) {
-		return !!(maybeType && (
-			_isFunction(maybeType.factory) ||
-			_isFunction(maybeType.serialize)
-		))
-	},
-
-	instanceOfType(type, maybeInstance) {
-		// const type = definition.type
-		return (
-			type && 
-			_isFunction(type.instanceOf) && 
-			type.instanceOf(maybeInstance)
-		)
-	}
-}
-
-// exports.isSchema = (maybeSchema) => {}
-// exports.isEntity = (maybeEntity) => {
-// 	return maybeEntity && _isFunction(maybeEntity.factory)
-// }
-
 exports.merge = () => {}

--- a/src/model.js
+++ b/src/model.js
@@ -1,24 +1,134 @@
+const Immutable = require('immutable')
+const Invariant = require('invariant')
+const _assign = require('lodash.assign')
+const _every = require('lodash.every')
+const _isArray = require('lodash.isarray')
+const _isPlainObject = require('lodash.isplainobject')
+const _isFunction = require('lodash.isfunction')
+
+const Identity = require('./identity')
+const Factory = require('./factory')
+
 const internals = {}
 
 exports.isModel = (maybeModel) => {}
 
-exports.create = (name, schema) => {
-	// verify schema
+exports.create = (spec) => {
+	Invariant(
+		_isPlainObject(spec) &&
+		spec.name && (typeof spec.name === "string")
+	, 'A plain object (spec) with a name is required to create a model')
 
-	const defaults = Schema.getDefaults(schema)
+	const {
+		name,
+		defaults
+	} = spec
 
-	const identity = Identity.create(name)
-	const factory = Factory.create(defaults)
+	let schema = spec.schema
+
+	Invariant(!defaults || Factory.isDefaults(defaults), 'When specifying defaults in the model spec it must be a plain object or Immutable Iterable')
+	Invariant(!schema || Schema.isSchema(schema), 'When specificying a schema for a model, it must be a valid schema definition')
+	
+	if (!schema) schema = {}
 
 	const modelPrototype = _assign(
 		Identity.create(name),
 		Factory.create(defaults),
-		internals.createParser(schema),
-		internals.createMerger(schema),
-		intenrals.createSerializer(serializer)
+		{
+			schema: () => schema
+		},
+		{
+			parse: exports.parse,
+			merge: exports.merge,
+			serialize: exports.serialize
+		}
 	)
 
 	let model = Object.create(modelPrototype)
 	
 	return model
 }
+
+exports.parse = function(attrs, options={}) {
+	const schema = options.schema || this.schema()
+
+	return attrs.map((modelValue, modelProp) => {
+		const definition = Schema.getDefinition(schema, modelProp)
+
+		// if no type was defined for this prop there is nothing for us to do
+		if (!modelValue || !definition) return modelValue;
+
+		if (Schema.isType(definition)) {
+			let type = definition
+
+			if (Schema.instanceOfType(type, modelValue)) {
+				// if the value is already and instance of what we're trying to make it
+				// there is nothing for us to do
+				return modelValue
+			} else {
+				return type.factory(modelValue)
+			}
+		} else if (Schema.isSchema(definition)) {
+			let nestedSchema = definition
+
+			if (
+				Immutable.Iterable.isIndexed(modelValue) && _isArray(nestedSchema) ||
+				Immutable.Iterable.isKeyed(modelValue) && _isPlainObject(nestedSchema)
+			) {
+				return exports.parse(modelValue, { schema: nestedSchema })
+			} else {
+				if (process.env.name !== 'production') {
+					Warning(`Value for '${stateProp}' ignored because it did not match the type defined in schema`);
+				}
+				return null;
+			}
+		} else {
+			return modelValue
+		}
+	})
+}
+
+
+const Schema = {
+	getDefinition(schema, prop) {
+		return _isArray(schema) ? schema[0] : 
+				schema ? schema[prop] :
+				null
+	},
+
+	isSchema(maybeSchema) {
+		return !!(
+			// objects go
+			_isPlainObject(maybeSchema) || 
+			// array with one value go
+			_isArray(maybeSchema) && maybeSchema.length === 1
+		) && _every(maybeSchema, (value, key) => {
+			return Schema.isType(value) || Schema.isSchema(value)
+		})
+	},
+
+	isType(maybeType) {
+		return !!(maybeType && _isFunction(maybeType.factory))
+	},
+
+	instanceOfType(type, maybeInstance) {
+		// const type = definition.type
+		return (
+			type && 
+			_isFunction(type.instanceOf) && 
+			type.instanceOf(maybeInstance)
+		)
+	},
+
+	getType(definition) {
+
+	}
+}
+
+// exports.isSchema = (maybeSchema) => {}
+// exports.isEntity = (maybeEntity) => {
+// 	return maybeEntity && _isFunction(maybeEntity.factory)
+// }
+
+exports.merge = () => {}
+exports.serialize = () => {}

--- a/src/model.js
+++ b/src/model.js
@@ -31,15 +31,15 @@ exports.create = (spec) => {
 	Invariant(
 		_isString(spec) ||
 		_isPlainObject(spec) &&
-		spec.name && _isString(spec.name)
-	, 'A name or a plain object (spec) with a name is required to create a model')
+		spec.typeName && _isString(spec.typeName)
+	, 'A typeName or a plain object (spec) with a typeName is required to create a model')
 
 	if (_isString(spec)) {
-		spec = { name: spec }
+		spec = { typeName: spec }
 	}
 
 	const {
-		name,
+		typeName,
 		defaults
 	} = spec
 
@@ -50,7 +50,7 @@ exports.create = (spec) => {
 	
 	if (!schema) schema = {}
 
-	const identity = Identity.create(name)
+	const identity = Identity.create(typeName)
 	const factory = Factory.create(defaults)
 	const merge = Merge.create(identity, factory)
 

--- a/src/model.js
+++ b/src/model.js
@@ -15,6 +15,7 @@ const Factory = require('./factory')
 const Merge = require('./merge')
 const Props = require('./props')
 const Schema = require('./schema')
+const Ref = require('./ref')
 
 const internals = {}
 
@@ -91,7 +92,8 @@ internals.parse = function(attrs, options={}) {
 
 			if (
 				!_isFunction(type.factory) || 
-				Schema.instanceOfType(type, modelValue)
+				Schema.instanceOfType(type, modelValue) ||
+				Ref.instanceOf(modelValue)
 			) {
 				// if the value is already and instance of what we're trying to make it
 				// there is nothing for us to do

--- a/src/model.js
+++ b/src/model.js
@@ -12,6 +12,7 @@ const _isUndefined = require('lodash.isundefined')
 
 const Identity = require('./identity')
 const Factory = require('./factory')
+const Merge = require('./merge')
 const State = require('./state')
 const Schema = require('./schema')
 
@@ -49,17 +50,21 @@ exports.create = (spec) => {
 	
 	if (!schema) schema = {}
 
+	const identity = Identity.create(name)
+	const factory = Factory.create(defaults)
+	const merge = Merge.create(identity, factory)
+
 	const modelPrototype = _assign(
 		Object.create(internals.Model.prototype), // makes `x instanceof Model` work
-		Identity.create(name),
-		Factory.create(defaults),
+		identity,
+		factory,
+		merge,
 		{
 			schema: () => schema
 		},
 		{
 			parse: exports.parse,
-			serialize: exports.serialize,
-			merge: State.merge
+			serialize: exports.serialize
 		}
 	)
 
@@ -152,7 +157,7 @@ exports.serialize = function(model, options) {
 			} else if (
 				Immutable.Iterable.isIndexed(modelValue) && _isArray(nestedSchema) ||
 				Immutable.Iterable.isKeyed(modelValue) && _isPlainObject(nestedSchema)
-			) {
+		) {
 				return exports.serialize.call(this, modelValue, _assign({}, options, { schema: nestedSchema }))
 			}
 		}

--- a/src/model.js
+++ b/src/model.js
@@ -69,7 +69,10 @@ exports.parse = function(attrs, options={}) {
 		if (Schema.isType(definition)) {
 			let type = definition
 
-			if (Schema.instanceOfType(type, modelValue)) {
+			if (
+				!_isFunction(type.factory) || 
+				Schema.instanceOfType(type, modelValue)
+			) {
 				// if the value is already and instance of what we're trying to make it
 				// there is nothing for us to do
 				return modelValue
@@ -155,7 +158,10 @@ const Schema = {
 	},
 
 	isType(maybeType) {
-		return !!(maybeType && _isFunction(maybeType.factory))
+		return !!(maybeType && (
+			_isFunction(maybeType.factory) ||
+			_isFunction(maybeType.serialize)
+		))
 	},
 
 	instanceOfType(type, maybeInstance) {

--- a/src/props.js
+++ b/src/props.js
@@ -1,6 +1,2 @@
-
-
 exports.cid = '__cid'
-
-// TODO: rename to `__typeName` in v2 (breaking change)
-exports.name = '__stateName'
+exports.name = '__typeName'

--- a/src/props.js
+++ b/src/props.js
@@ -1,4 +1,6 @@
 
 
 exports.cid = '__cid'
+
+// TODO: rename to `__typeName` in v2 (breaking change)
 exports.name = '__stateName'

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,4 +1,5 @@
 const Immutable = require('immutable')
+const Invariant = require('invariant')
 
 const _assign = require('lodash.assign')
 const _every = require('lodash.every')
@@ -9,6 +10,9 @@ const _isFunction = require('lodash.isfunction')
 const internals = {}
 
 internals.IterableSchema = function(iterable, itemSchema) {
+	Invariant(_isFunction(iterable), 'Iterable constructor required to create IterableSchema')
+	Invariant(exports.isType(itemSchema) || exports.isSchema(itemSchema), 'Item schema or type required to create IterableSchema')
+
 	_assign(this, {
 		getItemSchema: () => itemSchema,
 		factory: (val) => iterable(val),

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,60 @@
+const Immutable = require('immutable')
+
+const _assign = require('lodash.assign')
+const _every = require('lodash.every')
+const _isArray = require('lodash.isarray')
+const _isPlainObject = require('lodash.isplainobject')
+const _isFunction = require('lodash.isfunction')
+
+exports.getDefinition = (schema, prop) => {
+	return _isArray(schema) ? schema[0] : 
+			schema ? schema[prop] :
+			null
+}
+
+exports.isSchema = function(maybeSchema) {
+	return !!(
+		// objects go
+		_isPlainObject(maybeSchema) || 
+		// array with one value go
+		_isArray(maybeSchema) && maybeSchema.length === 1
+	) && _every(maybeSchema, (value, key) => {
+		return exports.isType(value) || exports.isSchema(value)
+	})
+}
+
+exports.isType = function(maybeType) {
+	return !!(maybeType && (
+		_isFunction(maybeType.factory) ||
+		_isFunction(maybeType.serialize)
+	))
+}
+
+exports.instanceOfType = function(type, maybeInstance) {
+	// const type = definition.type
+	return (
+		type && 
+		_isFunction(type.instanceOf) && 
+		type.instanceOf(maybeInstance)
+	)
+}
+
+exports.listOf = function(itemSchema) {
+	return [itemSchema]
+}
+
+exports.mapOf = function(itemSchema) {
+	return itemSchema
+}
+
+exports.setOf = function(itemSchema) {
+	return {
+		factory: (items, options) => (parse) => {
+			return Immutable.Set(parse(items, { schema: itemSchema }))
+		},
+
+		serialize: (set, options) => (serialize) => {
+			return serialize(set, _assign({}, options, { schema: itemSchema }))
+		}
+	}
+}

--- a/src/state.js
+++ b/src/state.js
@@ -37,8 +37,8 @@ exports.create = function(name, defaults) {
 		factory,
 		Merge.create(identity, factory),
 		{
-			parse: exports.parse,
-			serialize: exports.serialize
+			parse: internals.parse,
+			serialize: internals.serialize
 		}
 	)
 
@@ -53,11 +53,11 @@ exports.create = function(name, defaults) {
 	return state
 };
 
-exports.parse = (attrs) => {
+internals.parse = (attrs) => {
 	return attrs
 }
 
-exports.serialize = (state, optionsOrOmit) => {
+internals.serialize = (state, optionsOrOmit) => {
 	var options;
 
 	// TODO: deprecate passing anything but options in v2
@@ -72,7 +72,6 @@ exports.serialize = (state, optionsOrOmit) => {
 
 	if (!options) options = {}
 	const omitMeta = !_isUndefined(options.omitMeta) ? options.omitMeta : true
-
 
 	if (!omitMeta) {
 		return state.toJS();

--- a/src/state.js
+++ b/src/state.js
@@ -21,9 +21,11 @@ exports.create = function(name, defaults) {
 	const statePrototype = _assign(
 		Identity.create(name),
 		Factory.create(defaults),
-		internals.parser, 
-		internals.merger, 
-		internals.serializer
+		{
+			parse: exports.parse,
+			serialize: exports.serialize,
+			merge: exports.merge
+		}
 	)
 
 	let state = Object.create(statePrototype)
@@ -31,34 +33,26 @@ exports.create = function(name, defaults) {
 	return state
 };
 
-internals.parser = {
-	parse(attrs) {
-		return attrs
+exports.parse = (attrs) => {
+	return attrs
+}
+
+exports.serialize = (state, omitCid=true) => {
+	Invariant(exports.isState(state), 'State instance is required to serialize state');
+
+	if (!omitCid) {
+		return state.toJS();
+	} else {
+		return state.filter((value, key) => key !== internals.props.cid).toJS();
 	}
 }
 
-internals.serializer = {
-	serialize(state, omitCid=true) {
-		Invariant(exports.isState(state), 'State instance is required to serialize state');
-
-		if (!omitCid) {
-			return state.toJS();
-		} else {
-			return state.filter((value, key) => key !== internals.props.cid).toJS();
-		}
+exports.merge = (state, data) => {
+	if (exports.isState(state)) {
+		data = data.remove(internals.props.cid);
+	} else {
+		delete data.cid;
 	}
-}
 
-internals.merger = {
-	merge(state, data) {
-		if (exports.State.isState(state)) {
-			data = data.remove(internals.props.cid);
-		} else {
-			delete data.cid;
-		}
-
-		return state.merge(data);
-	}	
-}
-
-
+	return state.merge(data);
+}	

--- a/src/state.js
+++ b/src/state.js
@@ -46,7 +46,16 @@ exports.parse = (attrs) => {
 	return attrs
 }
 
-exports.serialize = (state, options) => {
+exports.serialize = (state, optionsOrOmit) => {
+	var options;
+
+	// TODO: deprecate passing anything but options in v2
+	if (_isPlainObject(optionsOrOmit)) {
+		options = optionsOrOmit
+	} else {
+		options = { omitMeta: optionsOrOmit }
+	}
+
 	Invariant(exports.isState(state) || Immutable.Iterable.isIterable(state), 'State instance or Immutable Iterable is required to serialize state');
 	Invariant(!options || _isPlainObject(options), 'Options, when passed, must be a plain object when serializing a state instance')
 

--- a/src/state.js
+++ b/src/state.js
@@ -3,7 +3,9 @@ const Invariant = require('invariant')
 const _isPlainObject = require('lodash.isplainobject')
 const _isUndefined = require('lodash.isundefined')
 const _assign = require('lodash.assign')
+const _forEach = require('lodash.foreach')
 const _keys = require('lodash.keys')
+const _functions = require('lodash.functions')
 
 const Factory = require('./factory')
 const Identity = require('./identity')
@@ -37,7 +39,13 @@ exports.create = function(name, defaults) {
 		}
 	)
 
-	let state = Object.create(statePrototype)
+	var state = Object.create(statePrototype)
+
+	// Binding each prototype method to the state itself. Unbound versions can still
+	// be used by accessing the prototype
+	_forEach(_functions(statePrototype), (methodName) => {
+		state[methodName] = statePrototype[methodName].bind(state)
+	})
 
 	return state
 };

--- a/src/state.js
+++ b/src/state.js
@@ -1,13 +1,14 @@
-var Immutable = require('immutable');
-var Invariant = require('invariant');
-var _isPlainObject = require('lodash.isplainobject');
-var _assign = require('lodash.assign')
+const Immutable = require('immutable')
+const Invariant = require('invariant')
+const _isPlainObject = require('lodash.isplainobject')
+const _isUndefined = require('lodash.isundefined')
+const _assign = require('lodash.assign')
 
 const Factory = require('./factory')
 const Identity = require('./identity')
 const Props = require('./props')
 
-var internals = {};
+const internals = {};
 
 internals.props = Props // lazy refactoring, boo
 
@@ -37,10 +38,15 @@ exports.parse = (attrs) => {
 	return attrs
 }
 
-exports.serialize = (state, omitCid=true) => {
+exports.serialize = (state, options) => {
 	Invariant(exports.isState(state), 'State instance is required to serialize state');
+	Invariant(!options || _isPlainObject(options), 'Options, when passed, must be a plain object when serializing a state instance')
 
-	if (!omitCid) {
+	if (!options) options = {}
+	const omitMeta = !_isUndefined(options.omitMeta) ? options.omitMeta : true
+
+
+	if (!omitMeta) {
 		return state.toJS();
 	} else {
 		return state.filter((value, key) => key !== internals.props.cid).toJS();

--- a/src/state.js
+++ b/src/state.js
@@ -39,7 +39,7 @@ exports.parse = (attrs) => {
 }
 
 exports.serialize = (state, options) => {
-	Invariant(exports.isState(state), 'State instance is required to serialize state');
+	Invariant(exports.isState(state) || Immutable.Iterable.isIterable(state), 'State instance or Immutable Iterable is required to serialize state');
 	Invariant(!options || _isPlainObject(options), 'Options, when passed, must be a plain object when serializing a state instance')
 
 	if (!options) options = {}

--- a/src/state.js
+++ b/src/state.js
@@ -12,6 +12,12 @@ const internals = {};
 
 internals.props = Props // lazy refactoring, boo
 
+internals.State = function(...args) {
+	Invariant(!(this instanceof internals.State), 'State should not be called with `new`')
+
+	return exports.create(...args)
+}
+
 // being a state instance is the same as having an identity... for now
 exports.isState = Identity.hasIdentity
 
@@ -20,6 +26,7 @@ exports.create = function(name, defaults) {
 	Invariant(!defaults || Factory.isDefaults(defaults), 'Defaults for state must be plain object or Immutable Iterable');
 
 	const statePrototype = _assign(
+		Object.create(internals.State.prototype), // makes `x instanceof State` work
 		Identity.create(name),
 		Factory.create(defaults),
 		{
@@ -63,3 +70,5 @@ exports.merge = function(state, data) {
 
 	return state.merge(data.remove(Props.cid));
 }	
+
+module.exports = _assign(internals.State, exports)

--- a/src/state.js
+++ b/src/state.js
@@ -53,12 +53,13 @@ exports.serialize = (state, options) => {
 	}
 }
 
-exports.merge = (state, data) => {
-	if (exports.isState(state)) {
-		data = data.remove(internals.props.cid);
-	} else {
-		delete data.cid;
+exports.merge = function(state, data) {
+	Invariant(this.instanceOf(state), `Instance of ${this.getName()} is required to merge it with new attributes`)
+	Invariant(_isPlainObject(data) || Immutable.Iterable.isIterable(data), 'Plain object or Immutable Iterable required as source to merge with the state instance')
+
+	if (!this.instanceOf(data)) {
+		data = this.factory(data)
 	}
 
-	return state.merge(data);
+	return state.merge(data.remove(Props.cid));
 }	

--- a/src/state.js
+++ b/src/state.js
@@ -5,6 +5,7 @@ const _isUndefined = require('lodash.isundefined')
 const _assign = require('lodash.assign')
 const _forEach = require('lodash.foreach')
 const _functions = require('lodash.functions')
+const Warning = require('warning')
 
 const Factory = require('./factory')
 const Identity = require('./identity')
@@ -60,7 +61,9 @@ internals.parse = (attrs) => {
 internals.serialize = (state, optionsOrOmit) => {
 	var options;
 
-	// TODO: deprecate passing anything but options in v2
+	// TODO: remove in v3.0
+	Warning(!_isPlainObject(optionsOrOmit), 'The `omitMeta` flag as a second argument to `state.serialize` has been deprecated. Instead, pass an object of `options` with an `omitMeta` flag as the second argument')
+
 	if (_isPlainObject(optionsOrOmit)) {
 		options = optionsOrOmit
 	} else {

--- a/src/state.js
+++ b/src/state.js
@@ -62,7 +62,7 @@ exports.serialize = (state, options) => {
 }
 
 exports.merge = function(state, data) {
-	Invariant(this.instanceOf(state), `Instance of ${this.getName()} is required to merge it with new attributes`)
+	Invariant(this.instanceOf(state), `Instance of ${this.typeName()} is required to merge it with new attributes`)
 	Invariant(Immutable.Iterable.isIterable(data) || _isPlainObject(data), 'Plain object or Immutable Iterable required as source to merge with the state instance')
 
 	if (!this.instanceOf(data)) {

--- a/src/state.js
+++ b/src/state.js
@@ -3,6 +3,7 @@ const Invariant = require('invariant')
 const _isPlainObject = require('lodash.isplainobject')
 const _isUndefined = require('lodash.isundefined')
 const _assign = require('lodash.assign')
+const _keys = require('lodash.keys')
 
 const Factory = require('./factory')
 const Identity = require('./identity')
@@ -62,10 +63,11 @@ exports.serialize = (state, options) => {
 
 exports.merge = function(state, data) {
 	Invariant(this.instanceOf(state), `Instance of ${this.getName()} is required to merge it with new attributes`)
-	Invariant(_isPlainObject(data) || Immutable.Iterable.isIterable(data), 'Plain object or Immutable Iterable required as source to merge with the state instance')
+	Invariant(Immutable.Iterable.isIterable(data) || _isPlainObject(data), 'Plain object or Immutable Iterable required as source to merge with the state instance')
 
 	if (!this.instanceOf(data)) {
-		data = this.factory(data)
+		let dataKeys = Immutable.Seq(Immutable.Iterable.isIterable(data) ? data.keys() : _keys(data))
+		data = this.factory(data).filter((val, key) => dataKeys.includes(key))
 	}
 
 	return state.merge(data.remove(Props.cid));

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 require('./state');
 require('./key-path');
 require('./ref');
+require('./model');

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 require('./state');
 require('./key-path');
 require('./ref');
+require('./schema');
 require('./model');

--- a/test/model.js
+++ b/test/model.js
@@ -150,7 +150,7 @@ Test('Model.parse', function(t) {
 })
 
 Test('Model.serialize', function(t) {
-	t.plan(12 + 3)
+	t.plan(15 + 3)
 
 	const OtherModel = Model.create({
 		name: 'woo'
@@ -190,6 +190,19 @@ Test('Model.serialize', function(t) {
 			serialize() { return 'never seen' },
 			instanceOf() { return false }
 		},
+
+		nestedList: Schema.listOf({
+			factory: (val) => val
+		}),
+
+		nestedSet: Schema.setOf({
+			factory: (val) => val
+		}),
+
+		nestedOrderedSet: Schema.orderedSetOf({
+			factory: (val) => val
+		}),
+		
 		optionTest: {
 			serialize(value, options) {
 				t.equal(options.omitMeta, omitMetaOptions.omitMeta, 'options are forwarded to the serialize methods of nested types')
@@ -217,7 +230,12 @@ Test('Model.serialize', function(t) {
 				'b': 'bbb'
 			},
 			notInstance: 'not-what-we-expect-it-to-be',
-			multiple: ['values', 'array']
+
+			multiple: ['values', 'array'],
+
+			nestedList: [outputA, outputB],
+			nestedSet: [outputA, outputB],
+			nestedOrderedSet: [outputC, outputB, outputA]
 		})
 		const serialized = TestModel.serialize(instance)
 
@@ -233,6 +251,9 @@ Test('Model.serialize', function(t) {
 			serialized.multiple.length === instance.get('multiple').count() &&
 			_.every(serialized.multiple, val => val === outputC)
 		, 'Lists are transformed to arrays and mapped with the serialize function of the type defintion')
+		t.ok(_.isArray(serialized.nestedList), 'nested Lists are serialized as arrays')
+		t.ok(_.isArray(serialized.nestedSet), 'nested Sets are serialized as arrays')
+		t.ok(_.isArray(serialized.nestedOrderedSet), 'nested OrderedSets are serialized as arrays')
 		t.ok(_.isUndefined(serialized.__cid), 'the client side identifier is omitted by default')
 	}, 'accepts a model instance')
 

--- a/test/model.js
+++ b/test/model.js
@@ -5,14 +5,29 @@ const _ = require('lodash')
 const Model = require('../lib/model')
 const Schema = require('../lib/schema')
 
+Test('Model', function(t) {
+	t.plan(2 + 1)
+
+	t.doesNotThrow(function() {
+		const model = Model('test-model')
+
+		t.ok(model instanceof Model, 'returns an instance of Model')
+	}, 'accepts same arguments as `Model.create`');
+
+	t.throws(function() {
+		const state = new Model('test-model')
+	}, 'does not allow being called as a constructor with `new` keyword')
+})
+
 Test('Model.create', function(t) {
-	t.plan(9 + 2 + 2 + 2)
+	t.plan(10 + 2 + 2 + 2)
 
 	t.doesNotThrow(function() {
 		const model = Model.create({
 			name: 'test-model'
 		})
 
+		t.ok(model instanceof Model, 'returns an object that is an instance of Model')
 		t.ok(_.isFunction(model.factory), 'returns an object with a factory method')
 		t.ok(_.isFunction(model.defaults), 'returns an object with a defaults method')
 		t.ok(_.isFunction(model.parse), 'returns an object with a parse method')
@@ -202,7 +217,7 @@ Test('Model.serialize', function(t) {
 		nestedOrderedSet: Schema.orderedSetOf({
 			factory: (val) => val
 		}),
-		
+
 		optionTest: {
 			serialize(value, options) {
 				t.equal(options.omitMeta, omitMetaOptions.omitMeta, 'options are forwarded to the serialize methods of nested types')

--- a/test/model.js
+++ b/test/model.js
@@ -164,6 +164,47 @@ Test('model.factory - parse', function(t) {
 	}, 'accepts raw attributes in Seq')
 })
 
+Test('model.typeName', function(t) {
+	t.plan(2)
+
+	const typeName = 'woo'
+	const TestModel = Model.create(typeName)
+
+	t.doesNotThrow(function() {
+		t.equal(TestModel.typeName(), typeName, 'returns the name which was used to create it')
+	}, 'allows for no arguments to be passed')
+})
+
+Test('model.defaults', function(t) {
+	t.plan(2)
+
+	const defaults = { a: 1, nested: { b: 2 }}
+	const TestModel = Model.create({
+		name: 'test',
+		defaults: defaults
+	})
+
+	t.doesNotThrow(function() {
+		t.ok(Immutable.Map(defaults).equals(TestModel.defaults()), 'returns the model defaults cast to a Immutable.Map')
+	}, 'allows for no arguments to be passed')
+})
+
+Test('model.schema', function(t) {
+	t.plan(2)
+
+	const schema = { 
+		a: { factory: _.identity }
+	}
+	const TestModel = Model.create({
+		name: 'test',
+		schema: schema
+	})
+
+	t.doesNotThrow(function() {
+		t.deepEqual(TestModel.schema(), schema, 'returns the model schema')
+	}, 'allows for no arguments to be passed')
+})
+
 Test('model.serialize', function(t) {
 	t.plan(15 + 3)
 

--- a/test/model.js
+++ b/test/model.js
@@ -335,3 +335,63 @@ Test('model.serialize', function(t) {
 		t.deepEqual(withContext, withoutContext, 'returns the same when called out of context')
 	}, 'can be called without context')
 })
+
+Test('model.merge', function(t) {
+	t.plan(3 + 4 + 2 + 2)
+
+	const rawDefaults = {
+		c: 1
+	}
+
+	const TestModel = Model.create({
+		name: 'test-state', 
+		defaults: rawDefaults
+	})
+	const OtherModel = Model.create({
+		name: 'other-state', 
+		defaults: rawDefaults
+	})
+
+	const baseInstance = TestModel.factory({
+		a: 1,
+		c: 3
+	})
+
+	const rawSource = {
+		a: 2,
+		b: 3
+	}
+
+	const sourceInstance = TestModel.factory(rawSource)
+	const otherInstance = OtherModel.factory(rawSource)
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestModel.merge(baseInstance, rawSource)
+
+		t.ok(TestModel.instanceOf(mergedInstance), 'returns an updated instance')
+		t.ok(mergedInstance.equals(baseInstance.merge(rawSource)), 'updated instance has attributes of source merged into instance')
+	}, 'accepts a Model instance and a plain object of new attributes')
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestModel.merge(baseInstance, sourceInstance)
+
+		t.ok(TestModel.instanceOf(mergedInstance), 'returns an updated instance')
+
+		t.ok(mergedInstance.equals(baseInstance.merge(rawDefaults, rawSource)), 'updated instance has attributes of source merged into base')
+		t.equals(mergedInstance.get('__cid'), baseInstance.get('__cid'), 'updated instance has client identifer `__cid` from base')
+	}, 'accepts two Model instances, a base and source')
+
+	t.doesNotThrow(function() {
+		const withContext = TestModel.merge(baseInstance, sourceInstance)
+		const withoutContext = TestModel.merge.call(null, baseInstance, sourceInstance)
+
+		t.ok(withContext.equals(withoutContext), 'returns the same when called out of context')
+	}, 'can be called without context')
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestModel.merge(baseInstance, otherInstance)
+
+		t.ok(TestModel.instanceOf(mergedInstance), 'returns an updated instance of the type of the base')
+	}, 'accepts a base and source instance with a different state type')
+})
+

--- a/test/model.js
+++ b/test/model.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 
 const Model = require('../lib/model')
 const Schema = require('../lib/schema')
+const Ref = require('../lib/ref')
 
 Test('Model', function(t) {
 	t.plan(2 + 1)
@@ -74,7 +75,7 @@ Test('Model.create', function(t) {
 })
 
 Test('model.factory - parse', function(t) {
-	t.plan(1 + 10 + 1)
+	t.plan(1 + 10 + 2 + 1)
 
 	const OtherModel = Model.create({
 		typeName: 'woo'
@@ -162,6 +163,16 @@ Test('model.factory - parse', function(t) {
 		t.ok(Immutable.OrderedSet([outputC, outputB, outputA]).equals(instance.get('nestedOrderedSet')), 'schema generated with `Schema.orderedSetOf` casts a value to an Immutable.OrderedSet')
 
 	}, 'accepts raw attributes in Seq')
+
+	t.doesNotThrow(() => {
+		const ref = Ref.create(['some', 'non-existing', 'path']) 
+
+		const instance = TestModel.factory({
+			a: ref
+		})
+
+		t.ok(ref.equals(instance.get('a')), 'when attribute value is a Ref instance it is not parsed any further')
+	}, 'accepts Ref instances as attribute values')
 
 	t.doesNotThrow(() => {
 		TestModel.factory.call(null)

--- a/test/model.js
+++ b/test/model.js
@@ -73,7 +73,7 @@ Test('Model.create', function(t) {
 	}, 'accepts a plain object spec with a name and schema')
 })
 
-Test('Model.parse', function(t) {
+Test('model.factory - parse', function(t) {
 	t.plan(1 + 10)
 
 	const OtherModel = Model.create({
@@ -164,7 +164,7 @@ Test('Model.parse', function(t) {
 	}, 'accepts raw attributes in Seq')
 })
 
-Test('Model.serialize', function(t) {
+Test('model.serialize', function(t) {
 	t.plan(15 + 3)
 
 	const OtherModel = Model.create({

--- a/test/model.js
+++ b/test/model.js
@@ -57,7 +57,7 @@ Test('Model.create', function(t) {
 })
 
 Test('Model.parse', function(t) {
-	t.plan(1 + 6)
+	t.plan(1 + 7)
 
 	const OtherModel = Model.create({
 		name: 'woo'
@@ -113,6 +113,7 @@ Test('Model.parse', function(t) {
 
 		const instance = TestModel.factory(attrs)
 
+		t.equal(instance.get('a'), outputA, 'value returned by factory of schema is used as value')
 		t.equal(instance.get('nonDefined'), 'prop', 'parser ignores any attributes not defined in schema')
 		t.equal(instance.getIn(['nested', 'b']), outputB, 'nested schema is applied to nested attributes')
 		t.ok(

--- a/test/model.js
+++ b/test/model.js
@@ -24,7 +24,7 @@ Test('Model.create', function(t) {
 
 	t.doesNotThrow(function() {
 		const model = Model.create({
-			name: 'test-model'
+			typeName: 'test-model'
 		})
 
 		t.ok(model instanceof Model, 'returns an object that is an instance of Model')
@@ -50,7 +50,7 @@ Test('Model.create', function(t) {
 			a: 'some-value'
 		}
 		const model = Model.create({
-			name: 'test-model',
+			typeName: 'test-model',
 			defaults: defaults
 		})
 
@@ -65,7 +65,7 @@ Test('Model.create', function(t) {
 		}
 
 		const model = Model.create({
-			name: 'test-model',
+			typeName: 'test-model',
 			schema: schema
 		})
 
@@ -77,7 +77,7 @@ Test('model.factory - parse', function(t) {
 	t.plan(1 + 10 + 1)
 
 	const OtherModel = Model.create({
-		name: 'woo'
+		typeName: 'woo'
 	})
 
 	const inputA = 'a';
@@ -122,7 +122,7 @@ Test('model.factory - parse', function(t) {
 	}
 
 	const TestModel = Model.create({
-		name: 'testModel',
+		typeName: 'testModel',
 		schema: schema
 	})
 
@@ -184,7 +184,7 @@ Test('model.defaults', function(t) {
 
 	const defaults = { a: 1, nested: { b: 2 }}
 	const TestModel = Model.create({
-		name: 'test',
+		typeName: 'test',
 		defaults: defaults
 	})
 
@@ -200,7 +200,7 @@ Test('model.schema', function(t) {
 		a: { factory: _.identity }
 	}
 	const TestModel = Model.create({
-		name: 'test',
+		typeName: 'test',
 		schema: schema
 	})
 
@@ -213,7 +213,7 @@ Test('model.serialize', function(t) {
 	t.plan(15 + 3 + 2)
 
 	const OtherModel = Model.create({
-		name: 'woo'
+		typeName: 'woo'
 	})
 
 	const noopFactory = (val) => val
@@ -273,7 +273,7 @@ Test('model.serialize', function(t) {
 	}
 
 	const TestModel = Model.create({
-		name: 'test-model',
+		typeName: 'test-model',
 		schema: schema
 	})
 
@@ -344,11 +344,11 @@ Test('model.merge', function(t) {
 	}
 
 	const TestModel = Model.create({
-		name: 'test-state', 
+		typeName: 'test-state', 
 		defaults: rawDefaults
 	})
 	const OtherModel = Model.create({
-		name: 'other-state', 
+		typeName: 'other-state', 
 		defaults: rawDefaults
 	})
 

--- a/test/model.js
+++ b/test/model.js
@@ -221,7 +221,7 @@ Test('model.schema', function(t) {
 })
 
 Test('model.serialize', function(t) {
-	t.plan(15 + 3 + 2)
+	t.plan(15 + 3 + 2 + 2)
 
 	const OtherModel = Model.create({
 		typeName: 'woo'
@@ -336,6 +336,18 @@ Test('model.serialize', function(t) {
 
 		t.equal(serialized.__cid, instance.get('__cid'), 'the client side identifier is included when passing `omitMeta: false` as an option')
 	}, 'accepts a model instance and an object of options')
+
+	t.doesNotThrow(() => {
+		const ref = Ref.create(['some', 'non-existing', 'path']) 
+
+		const instance = TestModel.factory({
+			a: ref
+		})
+
+		const serialized = TestModel.serialize(instance)
+
+		t.deepEqual(serialized.a, Ref.serialize(ref), 'when attribute value is a Ref instance it is serialized using `Ref.serialize`')
+	}, 'accepts Ref instances as attribute values')
 
 	t.doesNotThrow(() => {
 		const instance = TestModel.factory({ someProp: inputA })

--- a/test/model.js
+++ b/test/model.js
@@ -42,7 +42,7 @@ Test('Model.create', function(t) {
 	t.doesNotThrow(function() {
 		const model = Model.create('test-model')
 
-		t.equal(model.getName(), 'test-model', 'string as first argument is set as name of the model')
+		t.equal(model.typeName(), 'test-model', 'string as first argument is set as name of the model')
 	}, 'accepts a name for the model')
 
 	t.doesNotThrow(function() {

--- a/test/model.js
+++ b/test/model.js
@@ -57,7 +57,7 @@ Test('Model.create', function(t) {
 })
 
 Test('Model.parse', function(t) {
-	t.plan(1 + 7)
+	t.plan(2 + 8)
 
 	const OtherModel = Model.create({
 		name: 'woo'
@@ -67,6 +67,7 @@ Test('Model.parse', function(t) {
 	const outputA = 'A';
 	const outputB = 'B';
 	const outputC = 'C';
+	const outputD = 'D';
 
 	const schema = {
 		a: {
@@ -88,6 +89,15 @@ Test('Model.parse', function(t) {
 		alreadyInstance: {
 			factory() { return 'not-seen' },
 			instanceOf() { return true }
+		},
+		thunk: {
+			factory() {
+				return function(parse) {
+					t.ok(_.isFunction(parse), 'thunk is called with the parse method of the model')
+
+					return outputD
+				}
+			}
 		}
 	}
 
@@ -108,7 +118,8 @@ Test('Model.parse', function(t) {
 				'b': 'bbb'
 			},
 			alreadyInstance: 'already-what-it-should-be',
-			multiple: ['values', 'array']
+			multiple: ['values', 'array'],
+			thunk: 'a thunk value'
 		}
 
 		const instance = TestModel.factory(attrs)
@@ -123,6 +134,7 @@ Test('Model.parse', function(t) {
 		, 'arrays are cast as Lists and mapped with the factory of the type defintion')
 		t.ok(OtherModel.instanceOf(instance.get('nestedModel')), 'Model definitions are valid type definitions')
 		t.equal(instance.get('alreadyInstance'), attrs.alreadyInstance, 'mapping value with `factory` of type definition unless its `instanceOf` method returns truthy')
+		t.equal(instance.get('thunk'), outputD, 'value returned by factory thunk is used as value')
 
 	}, 'accepts raw attributes in Seq')
 })

--- a/test/model.js
+++ b/test/model.js
@@ -74,7 +74,7 @@ Test('Model.create', function(t) {
 })
 
 Test('model.factory - parse', function(t) {
-	t.plan(1 + 10)
+	t.plan(1 + 10 + 1)
 
 	const OtherModel = Model.create({
 		name: 'woo'
@@ -162,6 +162,10 @@ Test('model.factory - parse', function(t) {
 		t.ok(Immutable.OrderedSet([outputC, outputB, outputA]).equals(instance.get('nestedOrderedSet')), 'schema generated with `Schema.orderedSetOf` casts a value to an Immutable.OrderedSet')
 
 	}, 'accepts raw attributes in Seq')
+
+	t.doesNotThrow(() => {
+		TestModel.factory.call(null)
+	}, 'can be called without context')
 })
 
 Test('model.typeName', function(t) {
@@ -206,7 +210,7 @@ Test('model.schema', function(t) {
 })
 
 Test('model.serialize', function(t) {
-	t.plan(15 + 3)
+	t.plan(15 + 3 + 2)
 
 	const OtherModel = Model.create({
 		name: 'woo'
@@ -321,4 +325,13 @@ Test('model.serialize', function(t) {
 
 		t.equal(serialized.__cid, instance.get('__cid'), 'the client side identifier is included when passing `omitMeta: false` as an option')
 	}, 'accepts a model instance and an object of options')
+
+	t.doesNotThrow(() => {
+		const instance = TestModel.factory({ someProp: inputA })
+
+		const withContext = TestModel.serialize(instance)
+		const withoutContext = TestModel.serialize.call(null, instance)
+
+		t.deepEqual(withContext, withoutContext, 'returns the same when called out of context')
+	}, 'can be called without context')
 })

--- a/test/model.js
+++ b/test/model.js
@@ -1,0 +1,121 @@
+const Test = require('tape')
+const Model = require('../lib/model')
+const Immutable = require('immutable')
+const _ = require('lodash')
+
+Test('Model.create', function(t) {
+	t.plan(9 + 2 + 2)
+
+	t.doesNotThrow(function() {
+		const model = Model.create({
+			name: 'test-model'
+		})
+
+		t.ok(_.isFunction(model.factory), 'returns an object with a factory method')
+		t.ok(_.isFunction(model.defaults), 'returns an object with a defaults method')
+		t.ok(_.isFunction(model.parse), 'returns an object with a parse method')
+		t.ok(_.isFunction(model.serialize), 'returns an object with a serialize method')
+		t.ok(_.isFunction(model.merge), 'returns an object with a merge method')
+		t.ok(_.isFunction(model.instanceOf), 'returns an object with an instanceOf method')
+		t.ok(_.isFunction(model.collectionOf), 'returns an object with a collectionOf method')
+		t.ok(_.isFunction(model.schema), 'returns an object with a schema method')
+
+	}, 'accepst a plain object spec with a name for the model')
+
+	t.doesNotThrow(function() {
+		const defaults = {
+			a: 'some-value'
+		}
+		const model = Model.create({
+			name: 'test-model',
+			defaults: defaults
+		})
+
+		t.ok(Immutable.Map(defaults).equals(model.defaults()), 'some-value', 'returns an object with factory that uses specified defaults')
+	}, 'accepts a plain object spec with a name and factory defaults')
+
+	t.doesNotThrow(function() {
+		const schema = { 
+			foo: { 
+				factory: (value) => 'bar' 
+			}
+		}
+
+		const model = Model.create({
+			name: 'test-model',
+			schema: schema
+		})
+
+		t.deepEqual(model.schema(), schema, 'returns an object with schema method that returns the schema passed in')
+	}, 'accepts a plain object spec with a name and schema')
+})
+
+Test('Model.parse', function(t) {
+	t.plan(1 + 6)
+
+	const OtherModel = Model.create({
+		name: 'woo'
+	})
+
+	const inputA = 'a';
+	const outputA = 'A';
+	const outputB = 'B';
+	const outputC = 'C';
+
+	const schema = {
+		a: {
+			factory: (value) => {
+				t.equal(inputA, value, 'factory is called with the untransformed value');
+				
+				return outputA;
+			}
+		},
+		nested: {
+			b: {
+				factory: () => outputB
+			}
+		},
+		multiple: [{
+			factory: () => outputC 
+		}],
+		nestedModel: OtherModel,
+		alreadyInstance: {
+			factory() { return 'not-seen' },
+			instanceOf() { return true }
+		}
+	}
+
+	const TestModel = Model.create({
+		name: 'testModel',
+		schema: schema
+	})
+
+	t.doesNotThrow(() => {
+		const attrs = {
+			nonDefined: 'prop',
+			a: inputA,
+			nested: {
+				b: 'a nested value'
+			},
+			nestedModel: {
+				'a': 'aaa',
+				'b': 'bbb'
+			},
+			alreadyInstance: 'already-what-it-should-be',
+			multiple: ['values', 'array']
+		}
+
+		const instance = TestModel.factory(attrs)
+
+		t.equal(instance.get('nonDefined'), 'prop', 'parser ignores any attributes not defined in schema')
+		t.equal(instance.getIn(['nested', 'b']), outputB, 'nested schema is applied to nested attributes')
+		t.ok(
+			Immutable.List(instance.get('multiple')) &&
+			instance.get('multiple').count() === attrs.multiple.length &&
+			instance.get('multiple').every(val => val === outputC)
+		, 'arrays are cast as Lists and mapped with the factory of the type defintion')
+		t.ok(OtherModel.instanceOf(instance.get('nestedModel')), 'Model definitions are valid type definitions')
+		t.equal(instance.get('alreadyInstance'), attrs.alreadyInstance, 'mapping value with `factory` of type definition unless its `instanceOf` method returns truthy')
+
+	}, 'accepts raw attributes in Seq')
+})

--- a/test/model.js
+++ b/test/model.js
@@ -4,7 +4,7 @@ const Immutable = require('immutable')
 const _ = require('lodash')
 
 Test('Model.create', function(t) {
-	t.plan(9 + 2 + 2)
+	t.plan(9 + 2 + 2 + 2)
 
 	t.doesNotThrow(function() {
 		const model = Model.create({
@@ -21,6 +21,12 @@ Test('Model.create', function(t) {
 		t.ok(_.isFunction(model.schema), 'returns an object with a schema method')
 
 	}, 'accepst a plain object spec with a name for the model')
+
+	t.doesNotThrow(function() {
+		const model = Model.create('test-model')
+
+		t.equal(model.getName(), 'test-model', 'string as first argument is set as name of the model')
+	}, 'accepts a name for the model')
 
 	t.doesNotThrow(function() {
 		const defaults = {

--- a/test/schema.js
+++ b/test/schema.js
@@ -1,0 +1,107 @@
+const Test = require('tape')
+const Immutable = require('immutable')
+const _ = require('lodash')
+
+const Schema = require('../lib/schema')
+
+Test('Schema.isType', function(t) {
+	t.plan(4)
+
+	t.doesNotThrow(function() {
+		t.equal(Schema.isType({ factory() {} }), true, 'an object with a factory function is a type definition')
+		t.equal(Schema.isType({ serialize() {} }), true, 'an object with a serialize function is a type definition')
+		t.equal(Schema.isType({ somethingElse() {} }), false, 'an object without a factory or serialize function is not a type definition')
+	}, 'accepts any value')
+})
+
+Test('Schema.listOf', function(t) {
+	t.plan(5)
+
+	const itemType = {
+		factory: _.identity,
+		serialize: _.identity
+	}
+	t.doesNotThrow(function() {
+		const listOfSchema = Schema.listOf(itemType)
+
+		t.ok(Schema.isIterableSchema(listOfSchema), 'returns an IterableSchema')
+		t.deepEqual(listOfSchema.getItemSchema(), itemType, 'returns item schema when calling `getItemSchema` method')
+
+		const source = ["some", "array"]
+
+		t.ok(Immutable.List(source).equals(listOfSchema.factory(source)), 'casts an array to a List')
+		t.deepEqual(listOfSchema.serialize(Immutable.List(source)), source, 'serializes to an array')
+	}, 'accepts an Iterable constructor and type definition')
+})
+
+Test('Schema.setOf', function(t) {
+	t.plan(5)
+
+	const itemType = {
+		factory: _.identity,
+		serialize: _.identity
+	}
+	t.doesNotThrow(function() {
+		const setOfSchema = Schema.setOf(itemType)
+
+		t.ok(Schema.isIterableSchema(setOfSchema), 'returns an IterableSchema')
+		t.deepEqual(setOfSchema.getItemSchema(), itemType, 'returns item schema when calling `getItemSchema` method')
+
+		const source = ["some", "array"]
+
+		t.ok(Immutable.Set(source).equals(setOfSchema.factory(source)), 'casts an array to a Set')
+		t.deepEqual(setOfSchema.serialize(Immutable.Set(source)), source, 'serializes to an array')
+	}, 'accepts an Iterable constructor and type definition')
+})
+
+Test('Schema.orderedSetOf', function(t) {
+	t.plan(5)
+
+	const itemType = {
+		factory: _.identity,
+		serialize: _.identity
+	}
+	t.doesNotThrow(function() {
+		const orderedSetOfSchema = Schema.orderedSetOf(itemType)
+
+		t.ok(Schema.isIterableSchema(orderedSetOfSchema), 'returns an IterableSchema')
+		t.deepEqual(orderedSetOfSchema.getItemSchema(), itemType, 'returns item schema when calling `getItemSchema` method')
+
+		const source = ["some", "array"]
+
+		t.ok(Immutable.OrderedSet(source).equals(orderedSetOfSchema.factory(source)), 'casts an array to a OrderedSet')
+		t.deepEqual(orderedSetOfSchema.serialize(Immutable.OrderedSet(source)), source, 'serializes to an array')
+	}, 'accepts an Iterable constructor and type definition')
+})
+
+Test('Schema.isSchema', function(t) {
+	t.plan(5)
+
+	const type = {
+		factory: _.identity,
+		serialize: _.identity
+	}
+
+	t.doesNotThrow(function() {
+		t.equal(Schema.isSchema(type), false, 'a type definition is not a Schema')
+		t.equal(Schema.isSchema({ a: type }), true, 'an object with type definitions for every property is a Schema')
+		t.equal(Schema.isSchema([type]), true, 'an array with type definitions for every value is a Schema')
+		t.equal(Schema.isSchema({ a: type, b: { c: type, d: [type]}}), true, 'a schema with nested schemas is a Schema')
+	}, 'accepts any value')
+})
+
+Test('Schema.instanceOfType', function(t) {
+	t.plan(4)
+
+	const type = {
+		factory: _.identity,
+		instanceOf: (val) => val === 'a'
+	}
+
+
+	t.doesNotThrow(function() {
+		t.equal(Schema.instanceOfType(type, 'a'), true, 'returns true when the value passes the types instanceOf method')
+		t.equal(Schema.instanceOfType(type, 'b'), false, 'returns false when the value does not pass the types instanceOf method')
+		t.equal(Schema.instanceOfType({ factory: _.identity}, 'a'), false, 'returns false when the type does not have an instanceOf method')
+	}, 'accepts a type and a value to test')
+})

--- a/test/state.js
+++ b/test/state.js
@@ -184,7 +184,7 @@ Test('state.serialize', function(t) {
 	var rawInstance = {
 		__cid: 'some-client-id',
 		a: 1,
-		b: 3,
+		b: [3],
 		c: {
 			ca: 10,
 			cb: 30
@@ -201,7 +201,7 @@ Test('state.serialize', function(t) {
 
 		t.ok(_.isObject(serialized), 'returns a plain object');
 		t.equal(rawInstance.a, serialized.a, 'primitive values are serialized as is');
-		t.deepEqual(rawInstance.a, serialized.a, 'Lists are serialized as plain arrays');
+		t.deepEqual(rawInstance.b, serialized.b, 'Lists are serialized as plain arrays');
 		t.deepEqual(rawInstance.c, serialized.c, 'Maps are serialized as plain objects');
 		t.deepEqual([], serialized.f, 'Sets are serialized as plain arrays');
 		t.ok(

--- a/test/state.js
+++ b/test/state.js
@@ -208,7 +208,7 @@ Test('state.serialize', function(t) {
 			_.isEqual(rawInstance.d, serialized.d) &&
 			_.isEqual(rawInstance.e, serialized.e)
 		, 'nested Iterables are serialized to their plain counterparts recursively');
-	}, 'accepts an immutable model instance');
+	}, 'accepts a State instance');
 
 	t.doesNotThrow(function() {
 		var serialized = state.serialize(instance);
@@ -216,5 +216,37 @@ Test('state.serialize', function(t) {
 
 		t.ok(_.isUndefined(serialized.__cid), 'serialized object does not contain cid by default');
 		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true as the second argument');
-	}, 'accepts an immutable model and options with a flag to omit meta data');
+	}, 'accepts a State instance and options with a flag to omit meta data');
 });
+
+Test('state.merge', function(t) {
+	t.plan(3 + 4)
+
+	const TestState = State.create('test-state', {})
+
+	const baseInstance = TestState.factory({
+		a: 1
+	})
+
+	const rawSource = {
+		a: 2,
+		b: 3
+	}
+
+	const sourceInstance = TestState.factory(rawSource)
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestState.merge(baseInstance, rawSource)
+
+		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance')
+		t.ok(mergedInstance.equals(baseInstance.merge(rawSource)), 'updated instance has attributes of source merged into instance')
+	}, 'accepts a State instance and a plain object of new attributes')
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestState.merge(baseInstance, sourceInstance)
+
+		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance')
+		t.ok(mergedInstance.equals(baseInstance.merge(rawSource)), 'updated instance has attributes of source merged into base')
+		t.equals(mergedInstance.get('__cid'), baseInstance.get('__cid'), 'updated instance has client identifer `__cid` from base')
+	}, 'accepts two State instances, a base and source')
+})

--- a/test/state.js
+++ b/test/state.js
@@ -191,7 +191,7 @@ Test('state.collectionOf', function(t) {
 });
 
 Test('state.serialize', function(t) {
-	t.plan(7 + 3);
+	t.plan(7 + 3 + 2);
 
 	var state = State.create('test-model', {});
 
@@ -224,13 +224,20 @@ Test('state.serialize', function(t) {
 		, 'nested Iterables are serialized to their plain counterparts recursively');
 	}, 'accepts a State instance');
 
+
 	t.doesNotThrow(function() {
 		var serialized = state.serialize(instance);
 		var serializedIncluded = state.serialize(instance, { omitMeta: false });
 
 		t.ok(_.isUndefined(serialized.__cid), 'serialized object does not contain cid by default');
-		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true as the second argument');
+		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true for the `omitMeta` option');
 	}, 'accepts a State instance and options with a flag to omit meta data');
+
+	t.doesNotThrow(function() {
+		var serializedIncluded = state.serialize(instance, false); 
+
+		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true as the second argument');
+	}, 'accepts a State instance and a flag to omit meta data (backwards compat for 1.x)');
 });
 
 Test('state.merge', function(t) {

--- a/test/state.js
+++ b/test/state.js
@@ -40,6 +40,28 @@ Test('State.isState', function(t) {
 	}, 'does not throw');
 });
 
+Test('state.typeName', function(t) {
+	t.plan(2)
+
+	const typeName = 'woo'
+	const TestState = State.create(typeName)
+
+	t.doesNotThrow(function() {
+		t.equal(TestState.typeName(), typeName, 'returns the name which was used to create it')
+	}, 'allows for no arguments to be passed')
+})
+
+Test('state.defaults', function(t) {
+	t.plan(2)
+
+	const defaults = { a: 1, nested: { b: 2 }}
+	const TestState = State.create('test', defaults)
+
+	t.doesNotThrow(function() {
+		t.ok(Immutable.Map(defaults).equals(TestState.defaults()), 'returns the state defaults cast to a Immutable.Map')
+	}, 'allows for no arguments to be passed')
+})
+	
 Test('state.factory', function(t) {
 	t.plan(6 + 3 + 2  + 1);
 

--- a/test/state.js
+++ b/test/state.js
@@ -236,10 +236,15 @@ Test('state.serialize', function(t) {
 Test('state.merge', function(t) {
 	t.plan(3 + 4)
 
-	const TestState = State.create('test-state', {})
+	const rawDefaults = {
+		c: 1
+	}
+
+	const TestState = State.create('test-state', rawDefaults)
 
 	const baseInstance = TestState.factory({
-		a: 1
+		a: 1,
+		c: 3
 	})
 
 	const rawSource = {
@@ -260,7 +265,7 @@ Test('state.merge', function(t) {
 		const mergedInstance = TestState.merge(baseInstance, sourceInstance)
 
 		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance')
-		t.ok(mergedInstance.equals(baseInstance.merge(rawSource)), 'updated instance has attributes of source merged into base')
+		t.ok(mergedInstance.equals(baseInstance.merge(rawDefaults, rawSource)), 'updated instance has attributes of source merged into base')
 		t.equals(mergedInstance.get('__cid'), baseInstance.get('__cid'), 'updated instance has client identifer `__cid` from base')
 	}, 'accepts two State instances, a base and source')
 })

--- a/test/state.js
+++ b/test/state.js
@@ -3,14 +3,28 @@ var State = require('../lib/state');
 var Immutable = require('immutable');
 var _ = require('lodash');
 
+Test('State', function(t) {
+	t.plan(2 + 1)
+
+	t.doesNotThrow(function() {
+		const state = State('test-state', { a: 1, b: 2})
+
+		t.ok(state instanceof State, 'returns an instance of State')
+	}, 'accepts a name for the state and an object of defaults');
+
+	t.throws(function() {
+		const state = new State('test-state', { a: 1, b: 2})
+	}, 'does not allow being called as a constructor with `new` keyword')
+})
+
 Test('State.create', function(t) {
 	t.plan(2);
 
 	t.doesNotThrow(function() {
 		var state = State.create('test-state', { a: 1, b: 2});
 
-		// t.ok(state instanceof State, 'returns an instance of State');
-		t.ok(_.isFunction(state.factory), 'return an object with a factory')
+		t.ok(state instanceof State, 'returns an instance of State')
+		// t.ok(_.isFunction(state.factory), 'return an object with a factory')
 	}, 'accepts a name for the state and an object of defaults');
 });
 

--- a/test/state.js
+++ b/test/state.js
@@ -212,9 +212,9 @@ Test('state.serialize', function(t) {
 
 	t.doesNotThrow(function() {
 		var serialized = state.serialize(instance);
-		var serializedIncluded = state.serialize(instance, false);
+		var serializedIncluded = state.serialize(instance, { omitMeta: false });
 
 		t.ok(_.isUndefined(serialized.__cid), 'serialized object does not contain cid by default');
 		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true as the second argument');
-	}, 'accepts an immutable model and a flag to omit the model cid');
+	}, 'accepts an immutable model and options with a flag to omit meta data');
 });

--- a/test/state.js
+++ b/test/state.js
@@ -63,7 +63,7 @@ Test('state.defaults', function(t) {
 })
 	
 Test('state.factory', function(t) {
-	t.plan(6 + 3 + 2  + 1);
+	t.plan(6 + 3 + 2 + 1);
 
 
 	t.doesNotThrow(function() {
@@ -272,7 +272,7 @@ Test('state.serialize', function(t) {
 
 		t.deepEqual(serialized, noContext, 'returns the same when called out of context')
 
-	}, 'can be called withot context')
+	}, 'can be called without context')
 });
 
 Test('state.merge', function(t) {

--- a/test/state.js
+++ b/test/state.js
@@ -41,7 +41,7 @@ Test('State.isState', function(t) {
 });
 
 Test('state.factory', function(t) {
-	t.plan(6 + 3 + 2);
+	t.plan(6 + 3 + 2  + 1);
 
 
 	t.doesNotThrow(function() {
@@ -78,6 +78,11 @@ Test('state.factory', function(t) {
 
 		t.ok(childInstance.equals(instance.get('b')), 'returns instance with nested instances untouched');
 	}, 'accepts an object of attributes with instances of other states');
+
+	t.doesNotThrow(function() {
+		var state = State.create('test-state', { a: 1, b: 3});
+		state.factory.call(null)
+	}, 'can be called without context')
 });
 
 Test('state.factory - parse', function(t) {
@@ -164,9 +169,9 @@ Test('state.instanceOf', function(t) {
 	var instanceB = stateB.factory();
 
 	t.doesNotThrow(function() {
-		t.equal(stateA.instanceOf(instanceA), true, 'returns true for state instances created by it');
+		t.equal(stateA.instanceOf.call(null, instanceA), true, 'returns true for state instances created by it');
 		t.equal(stateA.instanceOf(instanceB), false, 'returns true for state instances created by other states');
-	}, 'accepts any value');
+	}, 'accepts any value and can be called without context');
 });
 
 Test('state.collectionOf', function(t) {
@@ -183,15 +188,15 @@ Test('state.collectionOf', function(t) {
 		var collectionB = Immutable.List([instanceB]);
 		var collectionMixed = Immutable.List([instanceA, instanceB]);
 
-		t.equal(stateA.collectionOf(collectionA), true, 'returns true for immutable collections that contain instances of that specific state');
+		t.equal(stateA.collectionOf.call(null, collectionA), true, 'returns true for immutable collections that contain instances of that specific state');
 		t.equal(stateA.collectionOf(collectionB), false, 'returns true for immutable collections that contain instances of other states');
 		t.equal(stateA.collectionOf(collectionMixed), false, 'returns false for immutable collections where instances of specific state or mixed with other values');
 
-	}, 'accepts any value');
+	}, 'accepts any value and can be called without context');
 });
 
 Test('state.serialize', function(t) {
-	t.plan(7 + 3 + 2);
+	t.plan(7 + 3 + 2 + 2);
 
 	var state = State.create('test-model', {});
 
@@ -238,10 +243,18 @@ Test('state.serialize', function(t) {
 
 		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true as the second argument');
 	}, 'accepts a State instance and a flag to omit meta data (backwards compat for 1.x)');
+
+	t.doesNotThrow(function() {
+		const serialized = state.serialize(instance)
+		const noContext = state.serialize.call(null, instance)
+
+		t.deepEqual(serialized, noContext, 'returns the same when called out of context')
+
+	}, 'can be called withot context')
 });
 
 Test('state.merge', function(t) {
-	t.plan(3 + 4)
+	t.plan(3 + 4 + 2)
 
 	const rawDefaults = {
 		c: 1
@@ -275,4 +288,11 @@ Test('state.merge', function(t) {
 		t.ok(mergedInstance.equals(baseInstance.merge(rawDefaults, rawSource)), 'updated instance has attributes of source merged into base')
 		t.equals(mergedInstance.get('__cid'), baseInstance.get('__cid'), 'updated instance has client identifer `__cid` from base')
 	}, 'accepts two State instances, a base and source')
+
+	t.doesNotThrow(function() {
+		const withContext = TestState.merge(baseInstance, sourceInstance)
+		const withoutContext = TestState.merge.call(null, baseInstance, sourceInstance)
+
+		t.ok(withContext.equals(withoutContext), 'returns the same when called out of context')
+	}, 'can be called without context')
 })

--- a/test/state.js
+++ b/test/state.js
@@ -276,13 +276,14 @@ Test('state.serialize', function(t) {
 });
 
 Test('state.merge', function(t) {
-	t.plan(3 + 4 + 2)
+	t.plan(3 + 4 + 2 + 2)
 
 	const rawDefaults = {
 		c: 1
 	}
 
 	const TestState = State.create('test-state', rawDefaults)
+	const OtherState = State.create('other-state', rawDefaults)
 
 	const baseInstance = TestState.factory({
 		a: 1,
@@ -295,6 +296,7 @@ Test('state.merge', function(t) {
 	}
 
 	const sourceInstance = TestState.factory(rawSource)
+	const otherInstance = OtherState.factory(rawSource)
 
 	t.doesNotThrow(function() {
 		const mergedInstance = TestState.merge(baseInstance, rawSource)
@@ -317,4 +319,10 @@ Test('state.merge', function(t) {
 
 		t.ok(withContext.equals(withoutContext), 'returns the same when called out of context')
 	}, 'can be called without context')
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestState.merge(baseInstance, otherInstance)
+
+		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance of the type of the base')
+	}, 'accepts a base and source instance with a different state type')
 })


### PR DESCRIPTION
I've been working on a first pass on the concept of a `Model`. It's like a `State`, but enhanced in that it accepts a `Schema` of other nested instances, so that it can do proper nested parsing and serialising. Additional ideas, like computed / derived properties or an id attribute, might also belong in it, but I've yet to figure out exactly why and how that should work.

The `Model` is *like* a `State`, but it isn't strictly inheriting from it. I really want to stay away from big hierarchical inheritance trees and rely on composing instead, where practical. In this case that meant refactoring `State` and splitting it up into several components that get mixed into a fresh prototype. 

So far, this extraction resulted in `Identity` and `Factory`. The `Model` uses them as well to get consistent and predictable similarities between it and `State`, while they implement their own `parse` and `serialize` methods.

For the longest time this looked like it would be a major version as it broke `instanceof State`, but I found a nice way to have that work after all. That leaves one more breaking change I'm aware off: the second parameter of `serialize` changed from a boolean flag to an options object with that flag embedded in it. I'll have a look whether we can make that backwards compatible, leaving it for deprecation and removal when we do break version later on.

While this seems in pretty good shape, I want to have a look at a couple of more things:

- The names of the new methods and the use of `this` (instead of `State` or `Model`) to reference them.
- Binding all prototype methods, so that they can be called outside of their context without breaking. I've gone back and forth on this a couple of times, wondering whether to favour the flexibility of letting the user bind it, or the predictability of being able the methods outside of context, like `list.map(TestModel.factory)` instead of requiring `list.map(TestModel.factory.bind(TestModel))`. In the end, I think predictability wins out, especially as I have a problem thinking of use cases for binding it to anything else but itself. The original unbound versions are still available too, and where not, the things retrieved from context (like `schema()` and `defaults()`) can be injected as an option.
- Documentation. With things settling a bit more an API reference would be the minimum.