### PR TITLE
Add mergeDeep to State, Models and Iterable Schemas

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -8,9 +8,10 @@ const Props = require('./props')
 
 const internals = {}
 
-exports.create = function(identity, factory) {
+exports.create = function(identity, factory, schema={}) {
 	return {
-		merge: internals.merge.bind(_assign({}, identity, factory))
+		merge: internals.merge.bind(_assign({}, identity, factory)),
+		mergeDeep: internals.mergeDeep.bind(_assign({}, identity, factory, schema))
 	}
 }
 
@@ -18,10 +19,21 @@ internals.merge = function(state, data) {
 	Invariant(this.instanceOf(state), `Instance of ${this.typeName()} is required to merge it with new attributes`)
 	Invariant(Immutable.Iterable.isIterable(data) || _isPlainObject(data), 'Plain object or Immutable Iterable required as source to merge with the state instance')
 
+	return state.merge(internals.mergableInstance.call(this, data));
+}
+
+internals.mergeDeep = function(state, data) {
+	Invariant(this.instanceOf(state), `Instance of ${this.typeName()} is required to merge deep it with new attributes`)
+	Invariant(Immutable.Iterable.isIterable(data) || _isPlainObject(data), 'Plain object or Immutable Iterable required as source to merge deep with the state instance')
+
+	return state.mergeDeep(internals.mergableInstance.call(this, data));
+}
+
+internals.mergableInstance = function(data) {
 	if (!this.instanceOf(data)) {
 		let dataKeys = Immutable.Seq(Immutable.Iterable.isIterable(data) ? data.keys() : _keys(data))
 		data = this.factory(data).filter((val, key) => dataKeys.includes(key))
 	}
 
-	return state.merge(data.remove(Props.cid).remove(Props.name));
+	return data.remove(Props.cid).remove(Props.name)
 }

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,9 +1,11 @@
 const Invariant = require('invariant')
 const Immutable = require('immutable')
 const _assign = require('lodash.assign')
+const _isFunction = require('lodash.isfunction')
 const _isPlainObject = require('lodash.isplainobject')
 const _keys = require('lodash.keys')
 
+const Schema = require('./schema')
 const Props = require('./props')
 
 const internals = {}
@@ -26,7 +28,53 @@ internals.mergeDeep = function(state, data) {
 	Invariant(this.instanceOf(state), `Instance of ${this.typeName()} is required to merge deep it with new attributes`)
 	Invariant(Immutable.Iterable.isIterable(data) || _isPlainObject(data), 'Plain object or Immutable Iterable required as source to merge deep with the state instance')
 
-	return state.mergeDeep(internals.mergableInstance.call(this, data));
+	
+
+	const mergeDeep = function(current, next, schema) {
+		// merge schema props shallowly, the rest deeply
+		const withSchema = next.filter((modelValue, modelProp) => {
+			if (!schema) return false
+
+			const definition = Schema.getDefinition(schema, modelProp)
+
+			return definition && (Schema.isType(definition) || Schema.isSchema(definition))
+		})
+		const withoutSchema = next.filter((modelValue, modelProp) => {
+			return !withSchema.has(modelProp)
+		})
+
+		return current.mergeDeep(withoutSchema).mergeWith(function(currentValue, nextValue, modelProp) {
+			const definition = Schema.getDefinition(schema, modelProp)
+
+			if (Schema.isType(definition)) {
+				let type = definition
+
+				if (!_isFunction(type.mergeDeep)) {
+					return nextValue
+				} else {
+					return type.mergeDeep(currentValue, nextValue)
+				}
+			} else if (Schema.isSchema(definition)) {
+				let nestedSchema = definition
+
+				if (nestedSchema.getItemSchema && _isFunction(nestedSchema.mergeDeep)) { // could be an Iterable schema
+					return nestedSchema.mergeDeep(currentValue, nextValue)
+				} else if (
+					Immutable.Iterable.isKeyed(currentValue) && _isPlainObject(nestedSchema)
+				) {
+					return mergeDeep(currentValue, nextValue, nestedSchema)
+				}
+			}
+			
+			// if we've arrived here, we didn't find a way to merge, so return the next value
+			return nextValue
+		}, withSchema)
+	}
+
+	const mergableInstance = internals.mergableInstance.call(this, data)
+	const modelSchema = this.schema && this.schema()
+
+	return mergeDeep(state, mergableInstance, modelSchema)
 }
 
 internals.mergableInstance = function(data) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -58,7 +58,8 @@ exports.isIterableSchema = function(maybeSchema) {
 exports.isType = function(maybeType) {
 	return !!(maybeType && (
 		_isFunction(maybeType.factory) ||
-		_isFunction(maybeType.serialize)
+		_isFunction(maybeType.serialize) ||
+		_isFunction(maybeType.mergeDeep)
 	))
 }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -24,6 +24,9 @@ internals.IterableSchema = function(iterable, itemSchema) {
 		serialize: (val, ...otherArgs) => {
 			const serialize = itemSchema.serialize || internals.idenity
 			return val.map((item) => serialize(item, ...otherArgs)).toJS()
+		},
+		mergeDeep: (current, next) => {
+			return iterable(next)
 		}
 	})
 }

--- a/test/model.js
+++ b/test/model.js
@@ -419,3 +419,115 @@ Test('model.merge', function(t) {
 	}, 'accepts a base and source instance with a different state type')
 })
 
+Test('model.mergeDeep', function(t) {
+	t.plan(3 + 8)
+
+	const OtherModel = Model.create({
+		typeName: 'woo'
+	})
+
+
+	const existingA = 'a'
+	const existingB = 'b'
+	const existingC = 'c'
+
+	const inputA = '1';
+	const inputB = '2';
+
+	const outputA = 'a1';
+	const outputB = 'b2';
+	const outputC = 'c3';
+
+	const schema = {
+		a: {
+			mergeDeep(existing, value, options) {
+				t.equal(existing, existingA, 'mergeDeep of type is called with the current value as first argument')
+				t.equal(value, inputA, 'mergeDeep of type is called with the to be merged value as the second argument')
+				t.ok(_.isPlainObject(options), 'mergeDeep of type is valled with the options passed to serialize')
+
+				return outputA
+			}
+		},
+		nested: {
+			b: {
+				mergeDeep: () => outputB
+			}
+		},
+		multiple: [{
+			mergeDeep: () => outputC
+		}],
+		nestedModel: OtherModel,
+		notInstance: {
+			mergeDeep() { return 'never seen' },
+			instanceOf() { return false }
+		},
+		notIncluded: {
+			mergeDeep() {
+				t.fail('not included properties should not be called')
+			}
+		},
+
+		nestedList: Schema.listOf({
+			factory: (val) => val
+		}),
+
+		nestedSet: Schema.setOf({
+			factory: (val) => val
+		}),
+
+		nestedOrderedSet: Schema.orderedSetOf({
+			factory: (val) => val
+		})
+	}
+
+	const TestModel = Model.create({
+		typeName: 'test-model',
+		schema: schema
+	})
+
+	const existing = TestModel.factory({
+		a: existingA,
+		nested: {
+			b: existingB
+		},
+		nestedModel: {
+			'a': existingA,
+			'b': existingB
+		},
+		notInstance: 'not-what-we-expect-it-to-be',
+		notTouched: existingA,
+
+		multiple: ['values', 'array'],
+
+		nestedList: [existingA, existingB],
+		nestedSet: [existingA, existingB],
+		nestedOrderedSet: [existingC, existingB, existingA]
+	})
+
+	t.doesNotThrow(function() {
+		const merged = TestModel.mergeDeep(existing, {
+			a: inputA,
+			nested: {
+				b: inputB
+			},
+			nestedModel: {
+				'a': 'aaa',
+				'b': 'bbb'
+			},
+			notInstance: 'wicked',
+			nestedList: [outputA, outputB],
+			nestedSet: [outputA, outputB],
+			nestedOrderedSet: [outputC, outputB, outputA]
+		})
+
+		t.equal(merged.get('a'), outputA, 'value returned by mergeDeep of schema is used as value')
+		t.equal(merged.getIn(['nested', 'b']), outputB, 'nested schema is applied to nested attributes')
+		t.ok(OtherModel.instanceOf(merged.get('nestedModel')), 'Model definitions are valid type definitions for merging deep')
+		t.equal(merged.get('notInstance'), existing.get('notInstance'), 'mergeDeep of schema definition not applied when schema has instanceOf method that returns falsey')
+		
+		t.ok(Immutable.List([outputA, outputB]).equals(merged.get('nestedList')), 'schema generated with `Schema.listOf` return only the new values as Lists merging is ambiguous')
+		t.ok(Immutable.Set([outputA, outputB]).equals(merged.get('nestedSet')), 'schema generated with `Schema.setOf` return only then new values as Sets merging is ambiguous')
+		t.ok(Immutable.OrderedSet([outputC, outputB, outputA]).equals(merged.get('nestedOrderedSet')), 'schema generated with `Schema.orderedSetOf` return only then ew value as OrderedSets merging is ambiguous')
+	}, 'accepts a Model instance and a mergable data')
+})
+

--- a/test/model.js
+++ b/test/model.js
@@ -420,7 +420,7 @@ Test('model.merge', function(t) {
 })
 
 Test('model.mergeDeep', function(t) {
-	t.plan(3 + 8)
+	t.plan(2 + 8)
 
 	const OtherModel = Model.create({
 		typeName: 'woo'
@@ -443,14 +443,13 @@ Test('model.mergeDeep', function(t) {
 			mergeDeep(existing, value, options) {
 				t.equal(existing, existingA, 'mergeDeep of type is called with the current value as first argument')
 				t.equal(value, inputA, 'mergeDeep of type is called with the to be merged value as the second argument')
-				t.ok(_.isPlainObject(options), 'mergeDeep of type is valled with the options passed to serialize')
 
-				return outputA
+				return existing + value
 			}
 		},
 		nested: {
 			b: {
-				mergeDeep: () => outputB
+				mergeDeep: (existing, value) => existing + value
 			}
 		},
 		multiple: [{
@@ -458,7 +457,7 @@ Test('model.mergeDeep', function(t) {
 		}],
 		nestedModel: OtherModel,
 		notInstance: {
-			mergeDeep() { return 'never seen' },
+			mergeDeep: (existing, value) => existing + value,
 			instanceOf() { return false }
 		},
 		notIncluded: {
@@ -494,7 +493,7 @@ Test('model.mergeDeep', function(t) {
 			'a': existingA,
 			'b': existingB
 		},
-		notInstance: 'not-what-we-expect-it-to-be',
+		notInstance: existingA,
 		notTouched: existingA,
 
 		multiple: ['values', 'array'],
@@ -514,7 +513,7 @@ Test('model.mergeDeep', function(t) {
 				'a': 'aaa',
 				'b': 'bbb'
 			},
-			notInstance: 'wicked',
+			notInstance: inputA,
 			nestedList: [outputA, outputB],
 			nestedSet: [outputA, outputB],
 			nestedOrderedSet: [outputC, outputB, outputA]
@@ -523,7 +522,7 @@ Test('model.mergeDeep', function(t) {
 		t.equal(merged.get('a'), outputA, 'value returned by mergeDeep of schema is used as value')
 		t.equal(merged.getIn(['nested', 'b']), outputB, 'nested schema is applied to nested attributes')
 		t.ok(OtherModel.instanceOf(merged.get('nestedModel')), 'Model definitions are valid type definitions for merging deep')
-		t.equal(merged.get('notInstance'), existing.get('notInstance'), 'mergeDeep of schema definition not applied when schema has instanceOf method that returns falsey')
+		t.equal(merged.get('notInstance'), outputA, 'mergeDeep of schema definition is still applied when schema has instanceOf method that returns falsey')
 		
 		t.ok(Immutable.List([outputA, outputB]).equals(merged.get('nestedList')), 'schema generated with `Schema.listOf` return only the new values as Lists merging is ambiguous')
 		t.ok(Immutable.Set([outputA, outputB]).equals(merged.get('nestedSet')), 'schema generated with `Schema.setOf` return only then new values as Sets merging is ambiguous')

--- a/test/state.js
+++ b/test/state.js
@@ -328,3 +328,61 @@ Test('state.merge', function(t) {
 		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance of the type of the base')
 	}, 'accepts a base and source instance with a different state type')
 })
+
+Test('state.mergeDeep', function(t) {
+	t.plan(3 + 4 + 2 + 2)
+
+	const rawDefaults = {
+		c: 1
+	}
+
+	const TestState = State.create('test-state', rawDefaults)
+	const OtherState = State.create('other-state', rawDefaults)
+
+	const baseInstance = TestState.factory({
+		a: 1,
+		c: 3,
+		d: {
+			e: 5
+		}
+	})
+
+	const rawSource = {
+		a: 2,
+		b: 3,
+		d: {
+			f: 6
+		}
+	}
+
+	const sourceInstance = TestState.factory(rawSource)
+	const otherInstance = OtherState.factory(rawSource)
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestState.mergeDeep(baseInstance, rawSource)
+
+		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance')
+		t.ok(mergedInstance.equals(baseInstance.mergeDeep(rawSource)), 'updated instance has attributes of source deep merged into instance')
+	}, 'accepts a State instance and a plain object of new attributes')
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestState.mergeDeep(baseInstance, sourceInstance)
+
+		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance')
+		t.ok(mergedInstance.equals(baseInstance.mergeDeep(rawDefaults, rawSource)), 'updated instance has attributes of source deep merged into base')
+		t.equals(mergedInstance.get('__cid'), baseInstance.get('__cid'), 'updated instance has client identifer `__cid` from base')
+	}, 'accepts two State instances, a base and source')
+
+	t.doesNotThrow(function() {
+		const withContext = TestState.mergeDeep(baseInstance, sourceInstance)
+		const withoutContext = TestState.mergeDeep.call(null, baseInstance, sourceInstance)
+
+		t.ok(withContext.equals(withoutContext), 'returns the same when called out of context')
+	}, 'can be called without context')
+
+	t.doesNotThrow(function() {
+		const mergedInstance = TestState.mergeDeep(baseInstance, otherInstance)
+
+		t.ok(TestState.instanceOf(mergedInstance), 'returns an updated instance of the type of the base')
+	}, 'accepts a base and source instance with a different state type')
+})


### PR DESCRIPTION
There's occasionally moments where you want to deeply merge new data, rather than merging in a shallow fashion. The occurence I ran into myself was merging partial nested resources, received through an API call and merging it with existing data. In this case, part of the data model had local values that would never be persisted or received. While the merging has the desired outcome on the root model, any nested models aren't merged with the instances that already existed, but rather replaced.

One thing to look out for is the behaviour of embedded `List`s, `Set`s and `OrderedSet`s, for which merging deeply is ambiguous. For example, does the `List` get the new items appended on to? Are non-occuring items trimmed, or do we try to find existing instances and update those in place? 

The safest approach would not be to merge at all, which is probably the initial behaviour I'd go for. From there we could go multiple directions, like options passed to indicate the required action, a `Collection` construct that's configured to do one specific thing, etc.