### PR TITLE
Fix bug where non-instances were attempted to be merged as instances

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -49,7 +49,10 @@ internals.mergeDeep = function(state, data) {
 			if (Schema.isType(definition)) {
 				let type = definition
 
-				if (!_isFunction(type.mergeDeep)) {
+				if (
+					!_isFunction(type.mergeDeep) || 
+					_isFunction(type.instanceOf) && !Schema.instanceOfType(type, currentValue)
+				) {
 					return nextValue
 				} else {
 					return type.mergeDeep(currentValue, nextValue)

--- a/test/model.js
+++ b/test/model.js
@@ -522,7 +522,7 @@ Test('model.mergeDeep', function(t) {
 		t.equal(merged.get('a'), outputA, 'value returned by mergeDeep of schema is used as value')
 		t.equal(merged.getIn(['nested', 'b']), outputB, 'nested schema is applied to nested attributes')
 		t.ok(OtherModel.instanceOf(merged.get('nestedModel')), 'Model definitions are valid type definitions for merging deep')
-		t.equal(merged.get('notInstance'), outputA, 'mergeDeep of schema definition is still applied when schema has instanceOf method that returns falsey')
+		t.equal(merged.get('notInstance'), inputA, 'next value is returned when definition schema has instanceOf method that returns falsey for existing value')
 		
 		t.ok(Immutable.List([outputA, outputB]).equals(merged.get('nestedList')), 'schema generated with `Schema.listOf` return only the new values as Lists merging is ambiguous')
 		t.ok(Immutable.Set([outputA, outputB]).equals(merged.get('nestedSet')), 'schema generated with `Schema.setOf` return only then new values as Sets merging is ambiguous')


### PR DESCRIPTION
Quick fix to a small mistake in determining the right logic for the deep merging. While working with a model that started off with `null` as the value for an instance, a deep merge threw an exception. Upon closer inspection, `mergeDeep` should respect `instanceOf` defined for a type.