### PR TITLE
Add defaults as option to type.factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,8 +431,9 @@ Returns a new instance (`Immutable.Map`) of the model using the model's defaults
 
 - `attributes` - `object` or any `Immutable.Iterable` of key-value pairs with which the type defaults will be overridden and amended. The model's schema is used to handle the creation of nested types. Nested `object`s and `array`s are converted to `Immutable.Map`and `Immutable.List` respectively, while any `Immutable.Iterable`s will be left untouched. 
 - `options` - `object` with the following keys
-  - `parse` - `function` as described by `state.parse` that is to be used instead of `state.parse` to transform the passed in `attributes`.
-  - `defaults` - plain `object` or `Immutable.Iterable` of default key-value pairs that are used as the base of the instance, instead of those defined for the `Model`. Nested values are propagated to nested models.
+  - `parse` - `function` as described by `state.parse` that is to be used instead of `model.parse` to transform the passed in `attributes`.
+  - `defaults` - plain `object` or `Immutable.Iterable` of default key-value pairs that are used as the base of the instance, instead of those defined for the model. Nested values are propagated to nested models.
+  - `schema` - schema definition that describes any nested models, to be used instead of the schema defined for the model. See the documentation for [`Schema`](#schema).
 
 ```js
 
@@ -531,6 +532,7 @@ By default it uses the `Schema` of the model to defer the parsing of other neste
 - `attributes` - (required) `Immutable.Map` of attributes. Any plain `object`s or `array`s are represented as `Immutable.Seq`s (`Keyed` and `Indexed` respectively), making it easy to deal with nested collections with a uniform API and giving you the opportunity to convert them to something else like a `Set`.
 - `options` - `object` with values for the following keys
   - `schema` - schema definition that describes any nested models, to be used instead of the schema defined for the model. See the documentation for [`Schema`](#schema).
+  - `defaults` - plain `object` or `Immutable.Iterable` of default key-value pairs that are used as the base of the instance, instead of those defined for the `Model`. Nested values are propagated to nested models.
 
 ```js
 const User = Vry.Model.create({

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Returns a new instance (`Immutable.Map`) of the state type using the type's defa
 - `attributes` - `object` or any `Immutable.Iterable` of key-value pairs with which the type defaults will be overridden and amended. Nested `object`s and `array`s are converted to `Immutable.Map`and `Immutable.List` respectively, while any `Immutable.Iterable`s will be left untouched. 
 - `options` - `object` with the following keys
   - `parse` - `function` as described by `state.parse` that is to be used instead of `state.parse` to transform the passed in `attributes`.
+  - `defaults` - plain `object` or `Immutable.Iterable` of default key-value pairs that are used as the base of the instance, instead of those defined for the `State`.
 
 ```js
 const User = Vry.State.create('user', {
@@ -249,6 +250,8 @@ A place to implement custom parsing behaviour. This method gets called by `state
 Must return a `Immutable.Iterable`. Any `Immutable.Seq`s returned are converted into `Immutable.Map` and `Immutable.List`. By default this method is a no-op, simply returning the attributes passed in.
 
 - `attributes` - (required) `Immutable.Map` of attributes. Any plain `object`s or `array`s are represented as `Immutable.Seq`s (`Keyed` and `Indexed` respectively), making it easy to deal with nested collections with a uniform API and giving you the opportunity to convert them to something else like a `Set`.
+- `options` - `object` with the following keys
+  - `defaults` - plain `object` or `Immutable.Iterable` of default key-value pairs that are used as the base of the instance, instead of those defined for the `State`.
 
 ```js
 const User = Vry.State.create('user', {
@@ -257,7 +260,7 @@ const User = Vry.State.create('user', {
   activated: false
 })
 
-User.parse = (attributes) => {
+User.parse = (attributes, options) => {
   // Make sure names start with a capital
   const name = attributes.get('name')
 
@@ -429,6 +432,7 @@ Returns a new instance (`Immutable.Map`) of the model using the model's defaults
 - `attributes` - `object` or any `Immutable.Iterable` of key-value pairs with which the type defaults will be overridden and amended. The model's schema is used to handle the creation of nested types. Nested `object`s and `array`s are converted to `Immutable.Map`and `Immutable.List` respectively, while any `Immutable.Iterable`s will be left untouched. 
 - `options` - `object` with the following keys
   - `parse` - `function` as described by `state.parse` that is to be used instead of `state.parse` to transform the passed in `attributes`.
+  - `defaults` - plain `object` or `Immutable.Iterable` of default key-value pairs that are used as the base of the instance, instead of those defined for the `Model`. Nested values are propagated to nested models.
 
 ```js
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash.isstring": "^4.0.1",
     "lodash.isundefined": "^3.0.1",
     "lodash.keys": "^4.0.7",
+    "lodash.omit": "^4.5.0",
     "lodash.uniqueid": "^3.0.0",
     "shortid": "^2.2.4",
     "warning": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vry",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Define `Model` and `Collection` like types to manage your `Immutable` data structures in a functional way",
   "main": "lib/index.js",
   "scripts": {

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,6 +1,7 @@
 const Invariant = require('invariant')
 const Immutable = require('immutable')
 const ShortId = require('shortid')
+const _assign = require('lodash.assign')
 const _isPlainObject = require('lodash.isplainobject')
 const _isFunction = require('lodash.isfunction')
 const _isArray = require('lodash.isarray')
@@ -35,11 +36,13 @@ internals.factory = function(rawEntity={}, options={}) {
 	, 'Raw entity, when passed, must be a plain object or Immutable Iterable')
 	Invariant(_isPlainObject(options), 'options, when passed, must be a plain object')
 	Invariant(!options.parse || _isFunction(options.parse), 'The `parse` prop of the options, when passed, must be a function')
+	Invariant(!options.defaults || exports.isDefaults(options.defaults), 'The `defaults` prop of the options, when passed, must be plain object or Immutable Iterable')
 
 	var parse = options.parse || this.parse || ((attrs) => attrs)
+	var defaults = Immutable.Map(options.defaults || this.defaults() || {})
 
 	// merge with with defaults and cast any nested native selections to Seqs
-	var entity = this.defaults().merge(Immutable.Map(rawEntity)).map((value, key) => {
+	var entity = defaults.merge(Immutable.Map(rawEntity)).map((value, key) => {
 		if (Immutable.Iterable.isIterable(value)) {
 			return value
 		}

--- a/src/model.js
+++ b/src/model.js
@@ -111,7 +111,15 @@ internals.parse = function(attrs, options={}) {
 			if (nestedSchema.getItemSchema) { // could be an Iterable schema
 				let itemSchema = nestedSchema.getItemSchema()
 
-				return nestedSchema.factory(this.parse(modelValue, { schema: itemSchema }), { defaults })
+				// I'm not sure why we did this parsing recursively like this, rather than letting the type itself
+				// deal with parsing itself. I'll leave it for while, in case we just didn't cover the use-case
+				// with a test properly.
+				// ---------------------
+				// 
+				// return nestedSchema.factory(this.parse(modelValue, { schema: itemSchema }), { defaults })
+				
+				return nestedSchema.factory(modelValue, { defaults })
+
 			} else if ( // support plain objects and arrays as they'll automatically get cast properly
 				Immutable.Iterable.isIndexed(modelValue) && _isArray(nestedSchema) ||
 				Immutable.Iterable.isKeyed(modelValue) && _isPlainObject(nestedSchema)

--- a/src/model.js
+++ b/src/model.js
@@ -81,12 +81,15 @@ exports.create = (spec) => {
 
 internals.parse = function(attrs, options={}) {
 	const schema = options.schema || this.schema()
+	const modelDefaults = Immutable.Map(options.defaults || this.defaults())
 
 	return attrs.map((modelValue, modelProp) => {
 		const definition = Schema.getDefinition(schema, modelProp)
+		const defaults = modelDefaults.get(modelProp)
 
 		// if no type was defined for this prop there is nothing for us to do
 		if (!modelValue || !definition) return modelValue;
+		
 
 		if (Schema.isType(definition)) {
 			let type = definition
@@ -99,22 +102,21 @@ internals.parse = function(attrs, options={}) {
 				// if the value is already and instance of what we're trying to make it
 				// there is nothing for us to do
 				return modelValue
-			} 
-			
-			return type.factory(modelValue)
+			}
 
+			return type.factory(modelValue, { defaults })
 		} else if (Schema.isSchema(definition)) {
 			let nestedSchema = definition
 
 			if (nestedSchema.getItemSchema) { // could be an Iterable schema
 				let itemSchema = nestedSchema.getItemSchema()
 
-				return nestedSchema.factory(this.parse(modelValue, { schema: itemSchema }))
+				return nestedSchema.factory(this.parse(modelValue, { schema: itemSchema }), { defaults })
 			} else if ( // support plain objects and arrays as they'll automatically get cast properly
 				Immutable.Iterable.isIndexed(modelValue) && _isArray(nestedSchema) ||
 				Immutable.Iterable.isKeyed(modelValue) && _isPlainObject(nestedSchema)
 			) {
-				return this.parse(modelValue, { schema: nestedSchema })
+				return this.parse(modelValue, { schema: nestedSchema, defaults })
 			} 
 		}
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -6,10 +6,11 @@ const _every = require('lodash.every')
 const _isArray = require('lodash.isarray')
 const _isPlainObject = require('lodash.isplainobject')
 const _isFunction = require('lodash.isfunction')
+const _omit = require('lodash.omit')
 
 const internals = {}
 
-internals.idenity = (val) => val
+internals.identity = (val) => val
 
 internals.IterableSchema = function(iterable, itemSchema) {
 	Invariant(_isFunction(iterable), 'Iterable constructor required to create IterableSchema')
@@ -17,12 +18,12 @@ internals.IterableSchema = function(iterable, itemSchema) {
 
 	_assign(this, {
 		getItemSchema: () => itemSchema,
-		factory: (val, ...otherArgs) => {
-			const factory = itemSchema.factory || internals.idenity
-			return iterable(val).map((item) => factory(item, ...otherArgs))
+		factory: (val, options, ...otherArgs) => {
+			const factory = itemSchema.factory || internals.identity
+			return iterable(val).map((item) => factory(item, _omit(options, 'defaults'), ...otherArgs))
 		},
 		serialize: (val, ...otherArgs) => {
-			const serialize = itemSchema.serialize || internals.idenity
+			const serialize = itemSchema.serialize || internals.identity
 			return val.map((item) => serialize(item, ...otherArgs)).toJS()
 		},
 		mergeDeep: (current, next) => {

--- a/test/schema.js
+++ b/test/schema.js
@@ -15,14 +15,15 @@ Test('Schema.isType', function(t) {
 })
 
 Test('Schema.listOf', function(t) {
-	t.plan(11)
+	t.plan(13)
 
-	const factoryOptions = { optionsFor: 'factory' }
+	const factoryOptions = { optionsFor: 'factory', defaults: 'should-not-be-forwarded' }
 	const serializeOptions = { optionsFor: 'serialize' }
 
 	const itemType = {
 		factory: (val, options) => {
-			t.deepEqual(factoryOptions, options, 'options are forwarded to the item schema factory')
+			t.deepEqual(_.omit(factoryOptions, 'defaults'), options, 'options are forwarded to the item schema factory')
+			t.notOk(options.defaults, 'defaults option is not forwarded to the item schema factory')
 			return val + 'modified'
 		},
 		serialize: (val, options) => {
@@ -53,14 +54,15 @@ Test('Schema.listOf', function(t) {
 })
 
 Test('Schema.setOf', function(t) {
-	t.plan(11)
+	t.plan(13)
 
-	const factoryOptions = { optionsFor: 'factory' }
+	const factoryOptions = { optionsFor: 'factory', defaults: 'should-not-be-forwarded' }
 	const serializeOptions = { optionsFor: 'serialize' }
 
 	const itemType = {
 		factory: (val, options) => {
-			t.deepEqual(factoryOptions, options, 'options are forwarded to the item schema factory')
+			t.deepEqual(_.omit(factoryOptions, 'defaults'), options, 'options are forwarded to the item schema factory')
+			t.notOk(options.defaults, 'defaults option is not forwarded to the item schema factory')
 			return val + 'modified'
 		},
 		serialize: (val, options) => {
@@ -91,14 +93,15 @@ Test('Schema.setOf', function(t) {
 })
 
 Test('Schema.orderedSetOf', function(t) {
-	t.plan(11)
+	t.plan(13)
 
-	const factoryOptions = { optionsFor: 'factory' }
+	const factoryOptions = { optionsFor: 'factory', defaults: 'should-not-be-forwarded' }
 	const serializeOptions = { optionsFor: 'serialize' }
 
 	const itemType = {
 		factory: (val, options) => {
-			t.deepEqual(factoryOptions, options, 'options are forwarded to the item schema factory')
+			t.deepEqual(_.omit(factoryOptions, 'defaults'), options, 'options are forwarded to the item schema factory')
+			t.notOk(options.defaults, 'defaults option is not forwarded to the item schema factory')
 			return val + 'modified'
 		},
 		serialize: (val, options) => {


### PR DESCRIPTION
I've been looking for ways to make Vry work better as a way to model API resources. Part of that is the necessity of being to handle multiple versions of a single and the same resource, in regards to the amount of properties returned by an endpoint. Further complicating this, a model might contain client-only properties, that an API might never return.

Allowing `defaults` to be overridden, as well as the `schema` (was already possible, but poorly documented), allows for partial instances  to be created that can then be merged with their more complete versions, while allowing to define defaults for client-only or base instances.