### PR TITLE
Remove features deprecated in v2

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -58,17 +58,8 @@ internals.parse = (attrs) => {
 	return attrs
 }
 
-internals.serialize = (state, optionsOrOmit) => {
+internals.serialize = (state, options) => {
 	var options;
-
-	// TODO: remove in v3.0
-	Warning(!_isPlainObject(optionsOrOmit), 'The `omitMeta` flag as a second argument to `state.serialize` has been deprecated. Instead, pass an object of `options` with an `omitMeta` flag as the second argument')
-
-	if (_isPlainObject(optionsOrOmit)) {
-		options = optionsOrOmit
-	} else {
-		options = { omitMeta: optionsOrOmit }
-	}
 
 	Invariant(exports.isState(state) || Immutable.Iterable.isIterable(state), 'State instance or Immutable Iterable is required to serialize state');
 	Invariant(!options || _isPlainObject(options), 'Options, when passed, must be a plain object when serializing a state instance')

--- a/test/state.js
+++ b/test/state.js
@@ -240,7 +240,7 @@ Test('state.collectionOf', function(t) {
 });
 
 Test('state.serialize', function(t) {
-	t.plan(7 + 5 + 2 + 2);
+	t.plan(7 + 5 + 2);
 
 	var state = State.create('test-model', {});
 
@@ -283,12 +283,6 @@ Test('state.serialize', function(t) {
 		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true for the `omitMeta` option');
 		t.equal(instance.get('__typeName'), serializedIncluded.__typeName, 'serialized object contains the state type name of the instance when passing true for the `omitMeta` option')
 	}, 'accepts a State instance and options with a flag to omit meta data');
-
-	t.doesNotThrow(function() {
-		var serializedIncluded = state.serialize(instance, false); 
-
-		t.equal(instance.get('__cid'), serializedIncluded.__cid, 'serialized object contains the client identifier of the instance when passing true as the second argument');
-	}, 'accepts a State instance and a flag to omit meta data (backwards compat for 1.x)');
 
 	t.doesNotThrow(function() {
 		const serialized = state.serialize(instance)


### PR DESCRIPTION
We had some features that were to be removed in v3 that I missed. All of these caused warnings in v2, so if you're code is warning free running against that, everything should be fine!